### PR TITLE
Remove Inflector

### DIFF
--- a/KustoSchemaTools/Changes/ScriptCompareChange.cs
+++ b/KustoSchemaTools/Changes/ScriptCompareChange.cs
@@ -1,7 +1,6 @@
 ﻿using Kusto.Language;
 using KustoSchemaTools.Model;
 using KustoSchemaTools.Parser;
-using System.Diagnostics.Metrics;
 using System.Text;
 
 namespace KustoSchemaTools.Changes
@@ -50,24 +49,16 @@ namespace KustoSchemaTools.Changes
                 sb.AppendLine($"</tr>");
                 if (before != null)
                 {
-
-
-
-
-
-
                     sb.AppendLine("<tr>");
                     sb.AppendLine($"    <td colspan=\"2\">From:</td>");
                     sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{before.Text.PrettifyKql()}</pre></td>");
                     sb.AppendLine("</tr>");
                 }
-                else
-                {
-                    sb.AppendLine("<tr>");
-                    sb.AppendLine($"    <td colspan=\"2\">{addActionText}:</td>");
-                    sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{change.Text.PrettifyKql()}</pre></td>");
-                    sb.AppendLine("</tr>");
-                }
+                sb.AppendLine("<tr>");
+                sb.AppendLine($"    <td colspan=\"2\">{addActionText}:</td>");
+                sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{change.Text.PrettifyKql()}</pre></td>");
+                sb.AppendLine("</tr>");
+
                 if (change.IsValid == false)
                 {
                     foreach (var diagnostic in diagnostics)

--- a/KustoSchemaTools/Changes/ScriptCompareChange.cs
+++ b/KustoSchemaTools/Changes/ScriptCompareChange.cs
@@ -1,6 +1,7 @@
 ﻿using Kusto.Language;
 using KustoSchemaTools.Model;
 using KustoSchemaTools.Parser;
+using System.Diagnostics.Metrics;
 using System.Text;
 
 namespace KustoSchemaTools.Changes
@@ -49,16 +50,24 @@ namespace KustoSchemaTools.Changes
                 sb.AppendLine($"</tr>");
                 if (before != null)
                 {
+
+
+
+
+
+
                     sb.AppendLine("<tr>");
                     sb.AppendLine($"    <td colspan=\"2\">From:</td>");
                     sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{before.Text.PrettifyKql()}</pre></td>");
                     sb.AppendLine("</tr>");
                 }
-                sb.AppendLine("<tr>");
-                sb.AppendLine($"    <td colspan=\"2\">{addActionText}:</td>");
-                sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{change.Text.PrettifyKql()}</pre></td>");
-                sb.AppendLine("</tr>");
-
+                else
+                {
+                    sb.AppendLine("<tr>");
+                    sb.AppendLine($"    <td colspan=\"2\">{addActionText}:</td>");
+                    sb.AppendLine($"    <td colspan=\"10\"><pre lang=\"kql\">{change.Text.PrettifyKql()}</pre></td>");
+                    sb.AppendLine("</tr>");
+                }
                 if (change.IsValid == false)
                 {
                     foreach (var diagnostic in diagnostics)

--- a/KustoSchemaTools/Helpers/Serialization.cs
+++ b/KustoSchemaTools/Helpers/Serialization.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace KustoSchemaTools.Helpers
 {
@@ -33,7 +32,7 @@ namespace KustoSchemaTools.Helpers
         public static ISerializer YamlPascalCaseSerializer { get; } =
             new SerializerBuilder()
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithNamingConvention(new CamelCaseNamingConvention())
                 .WithAttributeOverride<Function>(
                     c => c.Body,
                     new YamlMemberAttribute
@@ -44,7 +43,7 @@ namespace KustoSchemaTools.Helpers
                 .Build();
         public static IDeserializer YamlPascalCaseDeserializer { get; } =
             new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
 
         // Define a custom contract resolver that uses PascalCase naming convention
@@ -52,11 +51,18 @@ namespace KustoSchemaTools.Helpers
         {
             protected override string ResolvePropertyName(string propertyName)
             {
-                return base.ResolvePropertyName(PascalCaseNamingConvention.Instance.Apply(propertyName));
+                return base.ResolvePropertyName(Inflector.Inflector.Pascalize(propertyName));
             }
         }
 
-       
+        public class CamelCaseNamingConvention : INamingConvention
+        {
+            public string Apply(string value)
+            {
+                return Inflector.Inflector.Camelize(value);
+            }
+        }
+
         public static T Merge<T>(this T baseObject, T mergeObject)
         {
             var o1 = JObject.FromObject(baseObject, CloneJsonSerializer);

--- a/KustoSchemaTools/Helpers/Serialization.cs
+++ b/KustoSchemaTools/Helpers/Serialization.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace KustoSchemaTools.Helpers
 {
@@ -32,7 +33,7 @@ namespace KustoSchemaTools.Helpers
         public static ISerializer YamlPascalCaseSerializer { get; } =
             new SerializerBuilder()
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
-                .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithAttributeOverride<Function>(
                     c => c.Body,
                     new YamlMemberAttribute
@@ -43,7 +44,7 @@ namespace KustoSchemaTools.Helpers
                 .Build();
         public static IDeserializer YamlPascalCaseDeserializer { get; } =
             new DeserializerBuilder()
-                .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
         // Define a custom contract resolver that uses PascalCase naming convention
@@ -51,17 +52,10 @@ namespace KustoSchemaTools.Helpers
         {
             protected override string ResolvePropertyName(string propertyName)
             {
-                return base.ResolvePropertyName(Inflector.Inflector.Pascalize(propertyName));
+                return base.ResolvePropertyName(PascalCaseNamingConvention.Instance.Apply(propertyName));
             }
         }
 
-        public class CamelCaseNamingConvention : INamingConvention
-        {
-            public string Apply(string value)
-            {
-                return Inflector.Inflector.Camelize(value);
-            }
-        }
 
         public static T Merge<T>(this T baseObject, T mergeObject)
         {

--- a/KustoSchemaTools/Helpers/Serialization.cs
+++ b/KustoSchemaTools/Helpers/Serialization.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace KustoSchemaTools.Helpers
 {
@@ -32,7 +33,7 @@ namespace KustoSchemaTools.Helpers
         public static ISerializer YamlPascalCaseSerializer { get; } =
             new SerializerBuilder()
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults | DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
-                .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithAttributeOverride<Function>(
                     c => c.Body,
                     new YamlMemberAttribute
@@ -43,7 +44,7 @@ namespace KustoSchemaTools.Helpers
                 .Build();
         public static IDeserializer YamlPascalCaseDeserializer { get; } =
             new DeserializerBuilder()
-                .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
         // Define a custom contract resolver that uses PascalCase naming convention
@@ -51,18 +52,11 @@ namespace KustoSchemaTools.Helpers
         {
             protected override string ResolvePropertyName(string propertyName)
             {
-                return base.ResolvePropertyName(Inflector.Inflector.Pascalize(propertyName));
+                return base.ResolvePropertyName(PascalCaseNamingConvention.Instance.Apply(propertyName));
             }
         }
 
-        public class CamelCaseNamingConvention : INamingConvention
-        {
-            public string Apply(string value)
-            {
-                return Inflector.Inflector.Camelize(value);
-            }
-        }
-
+       
         public static T Merge<T>(this T baseObject, T mergeObject)
         {
             var o1 = JObject.FromObject(baseObject, CloneJsonSerializer);

--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Inflector" Version="1.0.0" />
     <PackageReference Include="Kusto.Toolkit" Version="1.5.0" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.2" />
@@ -15,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="11.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	  <PackageReference Include="YamlDotNet" Version="13.1.1" />
+    <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 
 </Project>

--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Inflector" Version="1.0.0" />
     <PackageReference Include="Kusto.Toolkit" Version="1.5.0" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.2" />

--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Inflector" Version="1.0.0" />
     <PackageReference Include="Kusto.Toolkit" Version="1.5.0" />
     <PackageReference Include="Markdig" Version="0.31.0" />
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.2" />
@@ -16,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="11.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YamlDotNet" Version="13.1.1" />
+	  <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Inflector library is not 1005 compatible with .net 6. It is now replaced with the casing functions from yamldotnet