### PR TITLE
Set default Lookback for MVs to empty

### DIFF
--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -11,7 +11,7 @@ namespace KustoSchemaTools.Model
         public string Folder { get; set; } = "";
         public string DocString { get; set; } = "";
         public string? EffectiveDateTime { get; set; }
-        public string Lookback { get; set; }
+        public string Lookback { get; set; } = "";
         public bool Backfill { get; set; } = false;
         public bool? UpdateExtentsCreationTime { get; set; }
         public bool AutoUpdateSchema { get; set; } = false;


### PR DESCRIPTION
This PR changes the default for the lookbacks to be empty