### PR TITLE
Add Entity Groups

### DIFF
--- a/KustoSchemaTools/Changes/EntityGroupChange.cs
+++ b/KustoSchemaTools/Changes/EntityGroupChange.cs
@@ -1,0 +1,75 @@
+﻿using Kusto.Language;
+using KustoSchemaTools.Model;
+using KustoSchemaTools.Parser;
+using System.Text;
+
+namespace KustoSchemaTools.Changes
+{
+
+
+    public class EntityGroupChange : BaseChange<List<Entity>>
+    {
+        public EntityGroupChange(string db, string entity, List<Entity>? from, List<Entity> to) : base("EntityGroup", entity, from ?? new List<Entity>(), to)
+        {
+            Db = db;
+            Init();
+        }
+
+        public string Db { get; }
+
+        private void Init()
+        {
+            var toEntityStrings = To.Select(t => $"cluster('{t.Cluster}').database('{t.Database}')").ToList();
+            var fromEntityStrings = From?.Select(f => $"cluster('{f.Cluster}').database('{f.Database}')").ToList() ?? new List<string>();
+
+            var added = toEntityStrings.Except(fromEntityStrings);
+            var removed = fromEntityStrings.Except(toEntityStrings);
+
+            var toEntityArr = string.Join(",", toEntityStrings);
+            var toScript = new DatabaseScriptContainer("EntityGroup", 3, $".create-or-alter entity_group {Entity} ({toEntityArr})");
+
+            if (added.Any() == false && removed.Any() == false)
+            {
+                return;
+            }
+
+            Scripts.Add(toScript);
+            var code = KustoCode.Parse(toScript.Text);
+            var diagnostics = code.GetDiagnostics();
+            toScript.IsValid = diagnostics.Any() == false;
+            var logo = toScript.IsValid.Value ? ":green_circle:" : ":red_circle:";
+
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"## {Entity}");
+            sb.AppendLine();
+            sb.AppendLine("<table>");
+            sb.AppendLine($"<tr></tr>");
+
+            if (added.Any())
+            {
+                sb.AppendLine("<tr>");
+                sb.AppendLine("<td colspan=\"2\">Added:</td>");
+                var addedIds = string.Join("<br>", added);
+                sb.AppendLine($"<td colspan=\"10\">{addedIds}:</td>");
+                sb.AppendLine("</tr>");
+            }
+            if (removed.Any())
+            {
+                sb.AppendLine("<tr>");
+                sb.AppendLine("<td colspan=\"2\">Removed:</td>");
+                var removedIds = string.Join("<br>", removed);
+                sb.AppendLine($"<td colspan=\"10\">{removedIds}:</td>");
+                sb.AppendLine("</tr>");
+            }
+            sb.AppendLine("<tr>");
+            sb.AppendLine($"<td colspan=\"2\">{logo}</td>");
+            sb.AppendLine($"<td colspan=\"10\"><pre lang=\"kql\">{toScript.Script.Text.PrettifyKql()}</pre></td>");
+            sb.AppendLine("</tr>");
+            sb.AppendLine("</table>");
+
+            Markdown = sb.ToString();
+        }
+    }
+
+}

--- a/KustoSchemaTools/Changes/ScriptCompareChange.cs
+++ b/KustoSchemaTools/Changes/ScriptCompareChange.cs
@@ -10,8 +10,6 @@ using Kusto.Language.Editor;
 
 namespace KustoSchemaTools.Changes
 {
-
-
     public class ScriptCompareChange : BaseChange<IKustoBaseEntity>
     {
         public ScriptCompareChange(string entity, IKustoBaseEntity? from, IKustoBaseEntity to) : base(to.GetType().Name, entity, from, to)

--- a/KustoSchemaTools/Model/Database.cs
+++ b/KustoSchemaTools/Model/Database.cs
@@ -22,6 +22,8 @@
 
         public List<DatabaseScript> Scripts { get; set; } = new List<DatabaseScript>();
 
+        public Dictionary<string, List<Entity>> EntityGroups { get; set; } = new Dictionary<string, List<Entity>>();
+
     }
 
 }

--- a/KustoSchemaTools/Model/Entity.cs
+++ b/KustoSchemaTools/Model/Entity.cs
@@ -1,0 +1,8 @@
+﻿namespace KustoSchemaTools.Model
+{
+    public class Entity
+    {
+        public string Database { get; set; }
+        public string Cluster { get; set; }
+    }
+}

--- a/KustoSchemaTools/Parser/KustoLoader/KustoEntityGroupBulkLoader.cs
+++ b/KustoSchemaTools/Parser/KustoLoader/KustoEntityGroupBulkLoader.cs
@@ -1,0 +1,19 @@
+﻿using Kusto.Data.Common;
+using KustoSchemaTools.Model;
+using KustoSchemaTools.Plugins;
+
+namespace KustoSchemaTools.Parser.KustoLoader
+{
+    public class KustoEntityGroupBulkLoader : IKustoBulkEntitiesLoader
+    {
+        const string LoadEntityGroups = ".show entity_groups | project EntityName = Name, parse_json(Entities) | mv-apply Entities to typeof(string) on (extend Cluster = extract('cluster\\\\([\"|\\'](.*?)[\"|\\']', 1,Entities) | extend Database = extract('database\\\\([\"|\\'](.*?)[\"|\\']', 1,Entities) | extend Body = bag_pack_columns(Cluster, Database) | summarize Body=make_list(Body) by EntityName)";
+        
+        public async Task Load(Database database, string databaseName, KustoClient client)
+        {
+            var tablesResult = await client.Client.ExecuteQueryAsync(databaseName, LoadEntityGroups, new ClientRequestProperties());
+            var entities = tablesResult.As<EnitityLoader<List<Entity>>>().ToDictionary(itm => itm.EntityName, itm => itm.Body);
+            database.EntityGroups = entities;
+        }
+
+    }
+}

--- a/KustoSchemaTools/Parser/YamlDatabaseHandler.cs
+++ b/KustoSchemaTools/Parser/YamlDatabaseHandler.cs
@@ -24,7 +24,7 @@ namespace KustoSchemaTools.Parser
             var dbFileName = Path.Combine(folder, "database.yml");
             var dbYaml = File.ReadAllText(dbFileName);
             var db = Serialization.YamlPascalCaseDeserializer.Deserialize<Database>(dbYaml);
-
+            db.Name = Database;
             foreach (var plugin in Plugins)
             {
                 await plugin.OnLoad(db, Path.Combine(Deployment, Database));


### PR DESCRIPTION
This PR adds Entity Groups as a supported feature to the warehouse config tooling. It also avoids rolling out only partial configured tables that don't exist in the database but have no column configuration.