### PR TITLE
Add external tables

### DIFF
--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>1.0.10</Version>
@@ -9,16 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="DiffPlex" Version="1.7.1" />
-    <PackageReference Include="Kusto.Toolkit" Version="1.7.5" />
-    <PackageReference Include="Markdig" Version="0.33.0" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.4" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.4" />
+	<PackageReference Include="DiffPlex" Version="1.7.2" />
+    <PackageReference Include="Kusto.Toolkit" Version="1.7.6" />
+    <PackageReference Include="Markdig" Version="0.34.0" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.5" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.5" />
     <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.3.24011" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="11.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="11.3.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YamlDotNet" Version="13.5.1" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 
 </Project>

--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -10,12 +10,12 @@
 
   <ItemGroup>
 	<PackageReference Include="DiffPlex" Version="1.7.2" />
-    <PackageReference Include="Kusto.Toolkit" Version="1.7.6" />
+    <PackageReference Include="Kusto.Toolkit" Version="1.7.7" />
     <PackageReference Include="Markdig" Version="0.34.0" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.5" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.5" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.3.24011" />
-    <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="11.3.5" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Language" Version="11.3.5" />
+    <PackageReference Include="Microsoft.Azure.Kusto.Tools" Version="12.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />

--- a/KustoSchemaTools/KustoSchemaTools.csproj
+++ b/KustoSchemaTools/KustoSchemaTools.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.11</Version>
-    <AssemblyVersion>1.0.11</AssemblyVersion>
+    <Version>1.0.12</Version>
+    <AssemblyVersion>1.0.12</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/KustoSchemaTools/Model/Database.cs
+++ b/KustoSchemaTools/Model/Database.cs
@@ -23,7 +23,7 @@
         public List<DatabaseScript> Scripts { get; set; } = new List<DatabaseScript>();
 
         public Dictionary<string, List<Entity>> EntityGroups { get; set; } = new Dictionary<string, List<Entity>>();
-        public Dictionary<string, ExternalTable> ExternalTables { get;  set; }
+        public Dictionary<string, ExternalTable> ExternalTables { get;  set; } = new Dictionary<string, ExternalTable>();
     }
 
 }

--- a/KustoSchemaTools/Model/Database.cs
+++ b/KustoSchemaTools/Model/Database.cs
@@ -23,7 +23,7 @@
         public List<DatabaseScript> Scripts { get; set; } = new List<DatabaseScript>();
 
         public Dictionary<string, List<Entity>> EntityGroups { get; set; } = new Dictionary<string, List<Entity>>();
-
+        public Dictionary<string, ExternalTable> ExternalTables { get;  set; }
     }
 
 }

--- a/KustoSchemaTools/Model/ExternalTable.cs
+++ b/KustoSchemaTools/Model/ExternalTable.cs
@@ -1,0 +1,158 @@
+﻿using KustoSchemaTools.Changes;
+using KustoSchemaTools.Parser;
+using System.Text;
+
+namespace KustoSchemaTools.Model
+{
+    public class ExternalTable : IKustoBaseEntity
+    {
+
+
+        public Dictionary<string, string>? Schema { get; set; }
+        public string Kind { get; set; } // sql, storage or delta
+        public string? Folder { get; set; }
+        public string? DocString { get; set; }
+        public string? ConnectionString { get; set; }
+        
+        #region Storage Properties
+
+        public string? Partitions { get; set; }
+        public string? PathFormat { get; set; }
+        public string? DataFormat { get; set; }
+        public string? NamePrefix { get; set; }
+        public string? Encoding { get; set; }
+
+        // In the with()-block
+        public string? FileExtensions { get; set; }
+        public bool IncludeHeaders { get; set; }
+        public bool Compressed { get; set; }
+
+        #endregion
+        #region SQL Properties
+        public string? SqlTable { get; set; }
+        public string? SqlDialect { get; set; }
+
+        // In the with()-block
+        public bool FireTriggres { get; set; }
+        public bool CreateIfNotExists { get; set; }
+        public string? PrimaryKey { get; set; }
+
+
+        #endregion
+
+        public List<DatabaseScriptContainer> CreateScripts(string name)
+        {
+            var container = new DatabaseScriptContainer
+            {
+                Kind = "External Table",
+                Script = new DatabaseScript
+                {
+                    Order = 22,
+                }
+            };
+
+            switch (Kind.ToLower())
+            {
+                case "delta":
+                    container.Script.Text = CreateDeltaScript(name);
+                    break;
+                case "sql":
+                    container.Script.Text = CreateSqlScript(name);
+                    break;
+                case "storage":
+                     container.Script.Text = CreateStorageScript(name);
+                    break;
+                default:
+                    throw new ArgumentException($"Kind {Kind} is not supported as external table");
+            }
+
+            return new List<DatabaseScriptContainer> { container };
+        }
+        private string CreateStorageScript(string name)
+        {
+            if (string.IsNullOrWhiteSpace(DataFormat)) throw new ArgumentException("DataFormat can't be empty");
+            if (string.IsNullOrWhiteSpace(ConnectionString)) throw new ArgumentException("StorageConnectionString can't be empty");
+            if (Schema?.Any() != true) throw new ArgumentException("Schema can't be empty");
+
+            var sb = new StringBuilder();
+            sb.AppendLine($".create-or-alter external table {name}");
+            sb.AppendLine($"({string.Join(", ", Schema.Select(c => $"{c.Key.BracketIfIdentifier()}:{c.Value}"))})");
+            sb.AppendLine("kind=storage");
+            if (string.IsNullOrWhiteSpace(Partitions) == false)
+            {
+                sb.AppendLine($"partition by ({Partitions})");
+            }
+            if (string.IsNullOrWhiteSpace(PathFormat) == false)
+            {
+                sb.AppendLine($"pathformat=({Partitions})");
+            }
+            sb.AppendLine($"dataformat={DataFormat}");
+            sb.AppendLine($"(h@'{ConnectionString}'");
+
+            var ext = string.IsNullOrWhiteSpace(FileExtensions) ? "" : FileExtensions.StartsWith(".") ? FileExtensions : "." + FileExtensions;
+            
+            sb.Append($"with(folder='{Folder}', docString='{DocString}', fileExtension='{ext}', compressed={Compressed} ");
+            if (IncludeHeaders)
+            {
+                sb.AppendLine(", includeHeaders=true");
+            }
+            if (string.IsNullOrWhiteSpace(Encoding) == false)
+            {
+                sb.Append($", encoding={Encoding}");
+            }
+            if (string.IsNullOrWhiteSpace(NamePrefix) == false)
+            {
+                sb.Append($", namePrefix={NamePrefix}");
+            }
+            sb.AppendLine(")");
+
+            return sb.ToString();
+        }
+
+        private string CreateSqlScript(string name)
+        {
+            if (Schema?.Any() != true) throw new ArgumentException("Schema can't be empty");
+            if (string.IsNullOrWhiteSpace(ConnectionString)) throw new ArgumentException("SqlConnectionString can't be empty");
+            if (string.IsNullOrWhiteSpace(SqlTable)) throw new ArgumentException("SqlTable can't be empty");
+
+            var sb = new StringBuilder();
+            sb.AppendLine($".create-or-alter external table {name}");
+            sb.AppendLine($"({string.Join(", ", Schema.Select(c => $"{c.Key.BracketIfIdentifier()}:{c.Value}"))})");
+            sb.AppendLine("kind=sql");
+            sb.AppendLine($"table={SqlTable}");
+            sb.AppendLine($"({ConnectionString})");
+            sb.Append($"with(folder='{Folder}', docString='{DocString}',createifnotexists={CreateIfNotExists}, fireTriggers={FireTriggres} ");
+            if(CreateIfNotExists && string.IsNullOrWhiteSpace(PrimaryKey) == false)
+            {
+                sb.Append($", primaryKey='{PrimaryKey}'");
+            }
+            if(string.IsNullOrWhiteSpace(SqlDialect) == false)
+            {
+                sb.Append($", sqlDialect='{SqlDialect}'");
+            }
+            sb.AppendLine(")");
+
+            return sb.ToString();
+        }
+
+        private string CreateDeltaScript(string name)
+        {
+            if (string.IsNullOrWhiteSpace(DataFormat)) throw new ArgumentException("DataFormat can't be empty");
+
+            var sb = new StringBuilder();
+            sb.AppendLine($".create-or-alter external table {name}");
+            if (Schema?.Any() == true)
+            {
+                sb.AppendLine($"({string.Join(", ", Schema.Select(c => $"{c.Key.BracketIfIdentifier()}:{c.Value}"))})");
+            }
+            sb.AppendLine("kind=delta");            
+            sb.AppendLine($"(h@'{ConnectionString}'");
+
+            var ext = string.IsNullOrWhiteSpace(FileExtensions) ? "" : FileExtensions.StartsWith(".") ? FileExtensions : "." + FileExtensions;
+
+            sb.AppendLine($"with(folder='{Folder}', docString='{DocString}', fileExtension='{ext}') ");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/KustoSchemaTools/Model/ExternalTable.cs
+++ b/KustoSchemaTools/Model/ExternalTable.cs
@@ -24,7 +24,7 @@ namespace KustoSchemaTools.Model
 
         // In the with()-block
         public string? FileExtensions { get; set; }
-        public bool IncludeHeaders { get; set; }
+        public string IncludeHeaders { get; set; }
         public bool Compressed { get; set; }
 
         #endregion
@@ -84,17 +84,17 @@ namespace KustoSchemaTools.Model
             }
             if (string.IsNullOrWhiteSpace(PathFormat) == false)
             {
-                sb.AppendLine($"pathformat=({Partitions})");
+                sb.AppendLine($"pathformat=({PathFormat})");
             }
             sb.AppendLine($"dataformat={DataFormat}");
-            sb.AppendLine($"(h@'{ConnectionString}'");
+            sb.AppendLine($"(h@'{ConnectionString}')");
 
             var ext = string.IsNullOrWhiteSpace(FileExtensions) ? "" : FileExtensions.StartsWith(".") ? FileExtensions : "." + FileExtensions;
-            
+
             sb.Append($"with(folder='{Folder}', docString='{DocString}', fileExtension='{ext}', compressed={Compressed} ");
-            if (IncludeHeaders)
+            if (string.IsNullOrEmpty(IncludeHeaders)==false)
             {
-                sb.AppendLine(", includeHeaders=true");
+                sb.AppendLine($", includeHeaders='{IncludeHeaders}'");
             }
             if (string.IsNullOrWhiteSpace(Encoding) == false)
             {

--- a/KustoSchemaTools/Parser/KustoLoader/KustoExternalTableBulkLoader.cs
+++ b/KustoSchemaTools/Parser/KustoLoader/KustoExternalTableBulkLoader.cs
@@ -1,0 +1,19 @@
+﻿using KustoSchemaTools.Model;
+
+namespace KustoSchemaTools.Parser.KustoLoader
+{
+    public class KustoExternalTableBulkLoader : KustoBulkEntityLoader<ExternalTable>
+    {
+        const string LoadExternalTables = ".show external tables | extend Properties = parse_json(Properties), ConnectionString=tostring(parse_json(ConnectionStrings)[0]) | project EntityName = TableName, Folder, DocString, Kind = case(tolower(TableType)  == \"sql\", \"sql\", tolower(TableType)  ==\"Delta\", \"delta\", \"storage\"), DataFormat = tolower(tostring(Properties.Format)), FileExtentions = tostring(Properties.FileExtension), IncludeHeaders = tostring(Properties.IncludeHeaders), Encoding = tostring(Properties.Encoding), NamePrefix = tostring(Properties.NamePrefix), Compressed = tobool(Properties.Compressed), SqlTable = tostring(Properties.TargetEntityName), CreateIfNotExists = tobool(Properties. CreateIfNotExists), PrimaryKey = tostring(Properties.PrimaryKey), SqlDialect = tostring(Properties.SqlDialect), Properties | project EntityName, Body = bag_pack_columns(Folder, DocString, Kind, DataFormat,FileExtentions, IncludeHeaders, Encoding, NamePrefix, Compressed, SqlTable, CreateIfNotExists, PrimaryKey, SqlDialect, Properties)";
+        const string LoadExternalTableAdditionalData = ".show database schema as csl script | search \"external table\" | parse DatabaseSchemaScript with * \"pathformat = \" PathFormat:string \"\\n\"* | parse DatabaseSchemaScript with * \"partition by \" Partitions:string \"\\n\"* | parse DatabaseSchemaScript with *\"h@\\\"\" ConnectionString:string \"\\\"\"* | parse DatabaseSchemaScript with \".create-or-alter external table \" Table:string \" (\" Columns:string \")\"* | mv-apply S=split(Columns,\",\") to typeof(string) on (extend C = split(S, ':') | extend B=bag_pack(trim('\\\\W',tostring(C[0])), C[1]) | summarize Schema=make_bag(B)) | extend  Partitions = trim(\"[\\\\(\\\\)\\\\r]\",Partitions), PathFormat = trim(\"\\\\)\",trim(\"\\\\r\",trim(\"\\\\(\",PathFormat))) | project EntityName=Table, Body= bag_pack_columns(Schema, ConnectionString, Partitions, PathFormat)";
+
+        public KustoExternalTableBulkLoader() : base(d => d.ExternalTables) { }
+
+        protected override IEnumerable<string> EnumerateScripts()
+        {
+            yield return LoadExternalTables;
+            yield return LoadExternalTableAdditionalData;
+
+        }
+    }
+}

--- a/KustoSchemaTools/Plugins/ExternalTablePlugin.cs
+++ b/KustoSchemaTools/Plugins/ExternalTablePlugin.cs
@@ -1,0 +1,11 @@
+﻿using KustoSchemaTools.Model;
+
+namespace KustoSchemaTools.Plugins
+{
+    public class ExternalTablePlugin : EntityPlugin<ExternalTable>
+    {
+        public ExternalTablePlugin(string subFolder = "external-tables", int minRowLength = 5) : base(db => db.ExternalTables, subFolder, minRowLength)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for external tables. It requires that the connection string in the yaml config matches the obfuscated string in the database. This applied only for using tables with managed identity or impersonation. External credential providers are not supported. 