### PR TITLE
Remove invalid parameter for MVs

### DIFF
--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -16,7 +16,6 @@ namespace KustoSchemaTools.Model
         public bool? UpdateExtentsCreationTime { get; set; }
         public bool AutoUpdateSchema { get; set; } = false;
         public List<string> DimensionTables { get; set; }
-        public bool AllowMaterializedViewsWithoutRowLevelSecurity { get; set; } = false;
         public RetentionAndCachePolicy RetentionAndCachePolicy { get; set; } = new RetentionAndCachePolicy();
         [YamlMember(ScalarStyle = ScalarStyle.Literal)]
         public string Query { get; set; }


### PR DESCRIPTION
This removes an invalid parameter for the idempotent .create-or-alter statement for MVs
