### PR TITLE
Remove backfill for MVs

### DIFF
--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -12,7 +12,6 @@ namespace KustoSchemaTools.Model
         public string DocString { get; set; } = "";
         public string? EffectiveDateTime { get; set; }
         public string Lookback { get; set; } = "";
-        public bool Backfill { get; set; } = false;
         public bool? UpdateExtentsCreationTime { get; set; }
         public bool AutoUpdateSchema { get; set; } = false;
         public List<string> DimensionTables { get; set; }


### PR DESCRIPTION
This PR removes the backfill parameter for materialized views, which is invalid for alter commands