### PR TITLE
Fix MVs on MVs

### DIFF
--- a/KustoSchemaTools/Parser/DatabaseCleanup.cs
+++ b/KustoSchemaTools/Parser/DatabaseCleanup.cs
@@ -65,6 +65,11 @@ namespace KustoSchemaTools.Parser
                 {
                     entity.Value.RetentionAndCachePolicy = null;
                 }
+
+                if (database.MaterializedViews.ContainsKey(entity.Value.Source))
+                {
+                    entity.Value.Kind = "materialized-view";
+                }
             }
 
             foreach (var entity in database.Functions)

--- a/KustoSchemaTools/Parser/KustoLoader/KustoContinuousExportBulkLoader.cs
+++ b/KustoSchemaTools/Parser/KustoLoader/KustoContinuousExportBulkLoader.cs
@@ -4,7 +4,7 @@ namespace KustoSchemaTools.Parser.KustoLoader
 {
     public class KustoContinuousExportBulkLoader : KustoBulkEntityLoader<ContinuousExport>
     {
-        const string LoadContinuousExports = @".show database hydro cslschema script 
+        const string LoadContinuousExports = @".show database cslschema script 
 | parse-where  DatabaseSchemaScript with '.create-or-alter continuous-export ' EntityName:string ' to table ' ExternalTable:string ' with (forcedLatency=time(' ForcedLatency:timespan '), intervalBetweenRuns=time('IntervalBetweenRuns:timespan '), sizeLimit='SizeLimit:long', distributed='Distributed:bool', managedIdentity='ManagedIdentity:string') <| ' Query:string
 | project EntityName=trim("" "",EntityName), Body = bag_pack(
     'ExternalTable', ExternalTable,


### PR DESCRIPTION
The load scripts for MVs don't can't fetch information if the MV is built on top of a table or a MV. The old behavior is that it defaults to table. The new implementation will consolidate this value based on existing materialized views.