### PR TITLE
Add Partitioning Policy

### DIFF
--- a/KustoSchemaTools/Model/PartitioningPolicy.cs
+++ b/KustoSchemaTools/Model/PartitioningPolicy.cs
@@ -1,0 +1,81 @@
+﻿using KustoSchemaTools.Changes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KustoSchemaTools.Model
+{
+    public class PartitioningPolicy
+    {
+        public string TimePartitionColumn { get; set; }
+        public TimeSpan? RangeSize { get; set; }
+        public bool? OverrideCreationTime { get; set; }
+        public DateTime? Reference { get; set; }
+
+        public string? SecondaryPartition { get; set; }
+        public PartitionAssignmentMode? PartirionAssignmentMode { get; set; }
+        public int? MaxPartitionCount { get; set; }
+        public DateTime? EffectiveDateTime { get; set; }
+
+        public DatabaseScriptContainer CreateScript(string name, string entity)
+        {
+
+            var p1 = new
+            {
+                ColumnName = TimePartitionColumn,
+                Kind = "UniformRange",
+                Properties = new
+                {
+                    Reference = (Reference ?? DateTime.UtcNow).ToString("yyyy-MM-ddTHH:mm:ss"),
+                    RangeSize = (RangeSize ?? new TimeSpan(1, 0, 0, 0)).ToString(),
+                    OverrideCreationTime = OverrideCreationTime == true
+                }
+            };
+
+            var p2 = new
+            {
+                ColumnName = SecondaryPartition,
+                Kind = "Hash",
+                Properties = new 
+                {
+                    Function = "XxHash64",
+                    MaxPartitionCount = MaxPartitionCount ?? 128,
+                    PartitionAssignmentMode = PartirionAssignmentMode ?? PartitionAssignmentMode.Default
+                }
+            };
+
+            var items = new List<object>();
+            items.Add(p1);
+            if(string.IsNullOrWhiteSpace(SecondaryPartition) == false)
+            {
+                items.Add(p2);
+            }
+
+            var policy = new
+            {
+                EffectiveDateTime = (EffectiveDateTime ?? DateTime.UtcNow).ToString("yyyy-MM-dd"),
+                PartitionKeys = items
+            };
+                   
+
+            return new DatabaseScriptContainer("PartitioningPolicy", 50, $".alter {entity} {name} policy partitioning ```{JsonConvert.SerializeObject(policy, Formatting.None)}```");
+        }
+
+        public enum PartitionAssignmentMode
+        {
+            /// <summary>
+            /// The default assignment mode.
+            /// </summary>
+            Default = 0,
+
+            /// <summary>
+            /// Ignore the partition value when assigning a homogeneous extent, and assign them uniformly according to the extent ID.
+            /// </summary>
+            Uniform = 1,
+
+            /// <summary>
+            /// Assign homogeneous (partitioned) extents by their partition value, this means assignment ignores extent ID.
+            /// </summary>
+            ByPartition = 2,
+        }
+    }
+}

--- a/KustoSchemaTools/Model/Policy.cs
+++ b/KustoSchemaTools/Model/Policy.cs
@@ -1,0 +1,68 @@
+﻿using KustoSchemaTools.Changes;
+using KustoSchemaTools.Helpers;
+using Newtonsoft.Json;
+
+namespace KustoSchemaTools.Model
+{
+    public class Policy
+    {
+        public string? Retention { get; set; }
+        public string? HotCache { get; set; }
+        public PartitioningPolicy? Partitioning { get; set; }
+        public string? RowLevelSecurity { get; set; }
+
+
+        public List<DatabaseScriptContainer> CreateScripts(string name, string entity)
+        {
+            var scripts = new List<DatabaseScriptContainer>();
+            if (Retention != null)
+            {
+                scripts.Add(new DatabaseScriptContainer("SoftDelete", 60, $".alter-merge {entity} {name} policy retention softdelete={Retention}"));
+            }
+            if (HotCache != null)
+            {
+                scripts.Add(new DatabaseScriptContainer("HotCache", 70, $".alter {entity} {name} policy caching hot={HotCache}"));
+            }
+          
+            if (!string.IsNullOrEmpty(RowLevelSecurity))
+            {
+                scripts.Add(new DatabaseScriptContainer("RowLevelSecurity", 57, $".alter {entity} {name} policy row_level_security enable ```{RowLevelSecurity}```"));
+            }
+            else
+            {
+                scripts.Add(new DatabaseScriptContainer("RowLevelSecurity", 52, $".delete {entity} {name} policy row_level_security"));
+            }
+
+            if (Partitioning != null)
+            {
+                scripts.Add(Partitioning.CreateScript(name, entity));
+            }
+            return scripts;
+        }
+    }
+
+    public class TablePolicy : Policy
+    {
+
+        public List<UpdatePolicy>? UpdatePolicies { get; set; }
+        public bool RestrictedViewAccess { get; set; } = false;
+        public List<DatabaseScriptContainer> CreateScripts(string name)
+        {
+            var scripts = new List<DatabaseScriptContainer>();
+            scripts.AddRange(base.CreateScripts(name, "table"));
+            if (UpdatePolicies != null)
+            {
+                var policies = JsonConvert.SerializeObject(UpdatePolicies, Serialization.JsonPascalCase);
+                var upPriority = UpdatePolicies.Any() ? 59 : 50;
+                scripts.Add(new DatabaseScriptContainer("TableUpdatePolicy", upPriority, $".alter table {name} policy update ```{policies}```"));
+            }
+
+            var rvaPrio = RestrictedViewAccess ? 58 : 51;
+            scripts.Add(new DatabaseScriptContainer("RestrictedViewAccess", rvaPrio, $".alter table {name} policy restricted_view_access {(RestrictedViewAccess ? "true" : "false")}"));
+
+            return scripts;
+
+        }
+    }
+
+}

--- a/KustoSchemaTools/Model/RetentionAndCachePolicy.cs
+++ b/KustoSchemaTools/Model/RetentionAndCachePolicy.cs
@@ -2,6 +2,7 @@
 
 namespace KustoSchemaTools.Model
 {
+    [Obsolete("Use policies instead")]
     public class RetentionAndCachePolicy
     {
         public string? Retention { get; set; }
@@ -9,6 +10,8 @@ namespace KustoSchemaTools.Model
 
         public List<DatabaseScriptContainer> CreateScripts(string name, string entity)
         {
+            if (entity != "database") throw new NotImplementedException();
+
             var scripts = new List<DatabaseScriptContainer>();
             if (Retention != null)
             {

--- a/KustoSchemaTools/Parser/KustoLoader/EnitityLoader.cs
+++ b/KustoSchemaTools/Parser/KustoLoader/EnitityLoader.cs
@@ -3,6 +3,7 @@
     public class EnitityLoader<T>
     {
         public string EntityName { get; set; }
+        public string EntityType { get; set; }
         public T Body { get; set; }
     }
 }

--- a/KustoSchemaTools/Parser/KustoLoader/KustoPartitioningPolicyLoader.cs
+++ b/KustoSchemaTools/Parser/KustoLoader/KustoPartitioningPolicyLoader.cs
@@ -1,0 +1,63 @@
+﻿using Kusto.Data.Common;
+using KustoSchemaTools.Model;
+using KustoSchemaTools.Plugins;
+
+namespace KustoSchemaTools.Parser.KustoLoader
+{
+    public class KustoPartitioningPolicyLoader : IKustoBulkEntitiesLoader
+    {
+        const string query = """          
+            .show database cslschema script 
+            | project tostring(DatabaseSchemaScript)
+            | where DatabaseSchemaScript contains 'policy partitioning'
+            | extend parts = split(DatabaseSchemaScript, " ")
+            | project Kind = tostring(parts[1]), Entity = tostring(parts[2]), Policy=parse_json(tostring(parse_json(tostring(parts[5]))))
+            | mv-apply Policy.PartitionKeys on (
+                project Policy_PartitionKeys, 
+                        ColumName = tostring(Policy_PartitionKeys.ColumnName), 
+                        Kind = toint(Policy_PartitionKeys.Kind), 
+                        MaxPartitionCount = toint(Policy_PartitionKeys.Properties.MaxPartitionCount), 
+                        PartitionAssignmentMode = toint(Policy_PartitionKeys.Properties.PartitionAssignmentMode),
+                        Reference = todatetime(Policy_PartitionKeys.Properties.Reference), 
+                        RangeSize = totimespan(Policy_PartitionKeys.Properties.RangeSize),
+                        OverrideCreationTime = Policy_PartitionKeys.Properties.OverrideCreationTime
+                | summarize TimePartitionColumn=take_anyif(ColumName, Kind==2), 
+                            RangeSize=take_anyif(RangeSize, Kind==2),
+                            OverrideCreationTime=tobool(take_anyif(OverrideCreationTime, Kind==2)),
+                            Reference=take_anyif(Reference, Kind==2),
+                            SecondaryPartition=take_anyif(ColumName, Kind==1),
+                            PartitionAssignmentMode=take_anyif(PartitionAssignmentMode, Kind==1),
+                            MaxPartitionCount=take_anyif(MaxPartitionCount, Kind==1)
+            )
+            | extend EffectiveDateTime = todatetime(Policy.EffectiveDateTime)
+            | project EntityName = Entity, EntityType = Kind,  Body = bag_pack_columns(TimePartitionColumn, RangeSize, OverrideCreationTime, Reference, SecondaryPartition, PartitionAssignmentMode, MaxPartitionCount, EffectiveDateTime)            
+            """;
+        public async Task Load(Database database, string databaseName, KustoClient client)
+        {
+            var partitioningPoliciesQueryResult = await client.Client.ExecuteQueryAsync(databaseName, query, new ClientRequestProperties());
+            var partitioningPolicies = partitioningPoliciesQueryResult.As<EnitityLoader<PartitioningPolicy>>().ToDictionary(itm => itm.EntityName, itm => itm.Body);
+
+            foreach (var item in partitioningPolicies)
+            {
+                if (database.Tables.ContainsKey(item.Key))
+                {
+                    var entity = database.Tables[item.Key];
+                    if (entity.Policies == null)
+                    {
+                        entity.Policies = new();
+                    }
+                    entity.Policies.Partitioning = item.Value;
+                }
+                if (database.MaterializedViews.ContainsKey(item.Key))
+                {
+                    var entity = database.MaterializedViews[item.Key];
+                    if (entity.Policies == null)
+                    {
+                        entity.Policies = new();
+                    }
+                    entity.Policies.Partitioning = item.Value;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR refactors table and materialized view polices. It flags the existing policies as obsolete and introduces a new policy object that encapsulates all policies. The DB cleanup will move existing policies to the new properties.

This refactoring was done to prepare the implementation of more policies. The first additional policy that ships with this PR is the partitioning policy.