### PR TITLE
Fix MV rollouts

### DIFF
--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -30,7 +30,7 @@ namespace KustoSchemaTools.Model
             var asyncSetup = isNew && Backfill == true;
 
 
-            var excludedProperies = new HashSet<string>(["Query", "Source", "Kind", "RetentionAndCachePolicy", "RowLevelSecurity"]);
+            var excludedProperies = new HashSet<string>(["Query", "Source", "Kind", "RetentionAndCachePolicy", "RowLevelSecurity", "Policies"]);
             if (!asyncSetup)
             {
                 excludedProperies.Add("EffectiveDateTime");


### PR DESCRIPTION
Policies were added recently but not added to the exclude list for properties in the `with` clause. This PR fixes it and remove the issues for rollouts