### PR TITLE
Restore RVA compatibility

### DIFF
--- a/KustoSchemaTools/Model/Table.cs
+++ b/KustoSchemaTools/Model/Table.cs
@@ -20,7 +20,9 @@ namespace KustoSchemaTools.Model
         public string DocString { get; set; }
         [Obsolete("Use policies instead")]
         public string? RowLevelSecurity { get; set; }
-                
+        [Obsolete("Use policies instead")]
+        public bool RestrictedViewAccess { get; set; } = false;
+
         public List<DatabaseScriptContainer> CreateScripts(string name, bool isNew)
         {
             var scripts = new List<DatabaseScriptContainer>();

--- a/KustoSchemaTools/Parser/DatabaseCleanup.cs
+++ b/KustoSchemaTools/Parser/DatabaseCleanup.cs
@@ -72,6 +72,8 @@ namespace KustoSchemaTools.Parser
                     policy.RowLevelSecurity = entity.Value.RowLevelSecurity;
                 }
 
+                policy.RestrictedViewAccess |= entity.Value.RestrictedViewAccess;
+
                 if (policy.Retention == database.DefaultRetentionAndCache.Retention)
                 {
                     policy.Retention = null;
@@ -109,6 +111,7 @@ namespace KustoSchemaTools.Parser
                 {
                     policy.RowLevelSecurity = entity.Value.RowLevelSecurity;
                 }
+
 
                 if (policy.Retention == database.DefaultRetentionAndCache.Retention)
                 {


### PR DESCRIPTION
With the update to the new policies RVAs were not loaded correctly. The final solution will load it to ne new policy objects directly. This is a quick fix to restore functionality.