### PR TITLE
Validate changes for deletions

### DIFF
--- a/KustoSchemaTools/Changes/DeletionChange.cs
+++ b/KustoSchemaTools/Changes/DeletionChange.cs
@@ -15,7 +15,17 @@ namespace KustoSchemaTools.Changes
 
         public string Entity { get; set; }
 
-        public List<DatabaseScriptContainer> Scripts => new List<DatabaseScriptContainer> { new DatabaseScriptContainer("Deletion", 0, $".drop {EntityType} {Entity}") };
+        public List<DatabaseScriptContainer> Scripts
+        {
+            get
+            {
+                var sc = new DatabaseScriptContainer("Deletion", 0, $".drop {EntityType} {Entity}");
+                var code = KustoCode.Parse(sc.Text);
+                var diagnostics = code.GetDiagnostics();
+                sc.IsValid = diagnostics.Any() == false;
+                return new List<DatabaseScriptContainer> { sc };
+            }
+        }
 
         public string Markdown
         {


### PR DESCRIPTION
This PR adds script validation to deletions. Before this was not evaluated and was set to null. This resulted in scripts being not executed.