### PR TITLE
Escape database names with `-`and multiline parameters

### DIFF
--- a/KustoSchemaTools/Model/Function.cs
+++ b/KustoSchemaTools/Model/Function.cs
@@ -22,7 +22,7 @@ namespace KustoSchemaTools.Model
         {
             var properties = GetType().GetProperties()
                 .Where(p => p.GetValue(this) != null && p.Name != "Body" && p.Name != "Parameters")
-                .Select(p => $"{p.Name}=\"{p.GetValue(this)}\"");
+                .Select(p => $"{p.Name}=```{p.GetValue(this)}```");
             var propertiesString = string.Join(", ", properties);
 
             var parameters = Parameters;

--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -42,7 +42,7 @@ namespace KustoSchemaTools.Model
                 .Where(p => p.GetValue(this) != null && excludedProperies.Contains(p.Name) == false)
                 .Select(p => new {Name = p.Name, Value = p.GetValue(this) })
                 .Where(p => !string.IsNullOrWhiteSpace(p.Value?.ToString()))
-                .Select(p => $"{p.Name}=\"{p.Value}\""));
+                .Select(p => $"{p.Name}=```{p.Value}```"));
 
   
             if (asyncSetup)

--- a/KustoSchemaTools/Model/Table.cs
+++ b/KustoSchemaTools/Model/Table.cs
@@ -30,7 +30,7 @@ namespace KustoSchemaTools.Model
             {
                 var properties = string.Join(", ", GetType().GetProperties()
                     .Where(p => p.GetValue(this) != null && (p.Name == "Folder" || p.Name == "DocString"))
-                    .Select(p => $"{p.Name}=\"{p.GetValue(this)}\""));
+                    .Select(p => $"{p.Name}=```{p.GetValue(this)}```"));
 
                 scripts.Add(new DatabaseScriptContainer("CreateMergeTable", 30, $".create-merge table {name} ({string.Join(", ", Columns.Select(c => $"{c.Key.BracketIfIdentifier()}:{c.Value}"))})"));
             }


### PR DESCRIPTION
This PR uses the Kusto logic to escape database names that need to be escaped. The PR also changes the escape strategy for parameters in Tables, Functions and Materialized Views to support multiline parameters in the `with()` block.