### PR TITLE
Add additional information / validations

### DIFF
--- a/KustoSchemaTools/Changes/BaseChange.cs
+++ b/KustoSchemaTools/Changes/BaseChange.cs
@@ -20,10 +20,10 @@
         public List<DatabaseScriptContainer> Scripts { get; set; } = new List<DatabaseScriptContainer>();
 
 
-        public string Markdown { get; protected set; }
+        public string Markdown { get; set; }
 
         public bool IsAsync { get; set; }
-
+        public Comment Comment { get; set; }
     }
 
 }

--- a/KustoSchemaTools/Changes/Comment.cs
+++ b/KustoSchemaTools/Changes/Comment.cs
@@ -1,0 +1,10 @@
+﻿namespace KustoSchemaTools.Changes
+{
+    public class Comment
+    {
+        public string Text { get; set; }
+        public bool FailsRollout { get; set; }
+        public CommentKind Kind { get; set; }
+
+    }
+}

--- a/KustoSchemaTools/Changes/CommentKind.cs
+++ b/KustoSchemaTools/Changes/CommentKind.cs
@@ -1,0 +1,11 @@
+﻿namespace KustoSchemaTools.Changes
+{
+    public enum CommentKind
+    {
+        Note,
+        Tip,
+        Important,
+        Warning,
+        Caution
+    }
+}

--- a/KustoSchemaTools/Changes/DeletionChange.cs
+++ b/KustoSchemaTools/Changes/DeletionChange.cs
@@ -51,5 +51,6 @@ namespace KustoSchemaTools.Changes
         }
 
 
+        public Comment Comment { get; set; }
     }
 }

--- a/KustoSchemaTools/Changes/FollowerChange.cs
+++ b/KustoSchemaTools/Changes/FollowerChange.cs
@@ -25,5 +25,6 @@ namespace KustoSchemaTools.Changes
 
         public List<DatabaseScriptContainer> Scripts { get; set; }
 
+        public Comment Comment { get; set; }
     }
 }

--- a/KustoSchemaTools/Changes/Heading.cs
+++ b/KustoSchemaTools/Changes/Heading.cs
@@ -13,6 +13,7 @@
         public List<DatabaseScriptContainer> Scripts => new List<DatabaseScriptContainer> { };
 
         public string Markdown => $"# {Entity}";
+        public Comment Comment { get; set; }
 
     }
 

--- a/KustoSchemaTools/Changes/IChange.cs
+++ b/KustoSchemaTools/Changes/IChange.cs
@@ -9,6 +9,7 @@
 
         public string Markdown { get; }
 
-    }
+        public Comment Comment { get; set; }
 
+    }
 }

--- a/KustoSchemaTools/KustoSchemaHandler.cs
+++ b/KustoSchemaTools/KustoSchemaHandler.cs
@@ -47,11 +47,21 @@ namespace KustoSchemaTools
                 var kustoDb = await dbHandler.LoadAsync();
                 var changes = DatabaseChanges.GenerateChanges(kustoDb, yamlDb, escapedDbName, Log);
 
-                isValid &= changes.All(itm => itm.Scripts.All(itm => itm.IsValid != false));
+                var comments = changes.Select(itm => itm.Comment).Where(itm => itm != null).ToList();
+
+        
+                isValid &= changes.All(itm => itm.Scripts.All(itm => itm.IsValid != false)) && comments.All(itm => itm.FailsRollout == false);
 
                 sb.AppendLine($"# {cluster.Name}/{escapedDbName} ({cluster.Url})");
 
-                if(changes.Count == 0)
+                foreach (var comment in comments)
+                {
+                    sb.AppendLine($"> [!{comment.Kind.ToString().ToUpper()}]");
+                    sb.AppendLine($"> {comment.Text}");
+                    sb.AppendLine();
+                }
+
+                if (changes.Count == 0)
                 {
                     sb.AppendLine("No changes detected");
                 }

--- a/KustoSchemaTools/Model/MaterializedView.cs
+++ b/KustoSchemaTools/Model/MaterializedView.cs
@@ -47,11 +47,11 @@ namespace KustoSchemaTools.Model
   
             if (asyncSetup)
             {
-                scripts.Add(new DatabaseScriptContainer("CreateMaterializedView", Kind == "table" ? 40 : 41, $".create async ifnotexists materialized-view with ({properties}) {name} on {Kind} {Source} {{ {Query} }}", true));
+                scripts.Add(new DatabaseScriptContainer("CreateMaterializedViewAsync", Kind == "table" ? 40 : 41, $".create async ifnotexists materialized-view with ({properties}) {name} on {Kind} {Source} {{ {Query} }}", true));
             }
             else
             {
-                scripts.Add(new DatabaseScriptContainer("CreateMaterializedView", Kind == "table" ? 40 : 41, $".create-or-alter materialized-view with ({properties}) {name} on {Kind} {Source} {{ {Query} }}"));
+                scripts.Add(new DatabaseScriptContainer("CreateAlterMaterializedView", Kind == "table" ? 40 : 41, $".create-or-alter materialized-view with ({properties}) {name} on {Kind} {Source} {{ {Query} }}"));
             }
             if (Policies != null)
             {


### PR DESCRIPTION
This PR adds the option to add comments to changes. These comments are rendered on top of the PR comment and they can be used to let a rollout fail.

When Materialized Views are created with backfills, it is validated if required data is available in hot cache or if the rollout will fail. 