### PR TITLE
Implement apply() for cluster configuration changes 

### DIFF
--- a/KustoSchemaTools.Tests/Changes/ClusterChangesTest.cs
+++ b/KustoSchemaTools.Tests/Changes/ClusterChangesTest.cs
@@ -18,8 +18,8 @@ namespace KustoSchemaTools.Tests.Changes
         public void GenerateChanges_WithIdenticalPolicies_ShouldDetectNoChanges()
         {
             // Arrange
-            var oldCluster = CreateClusterWithPolicy(0.2, 1, 2, 3);
-            var newCluster = CreateClusterWithPolicy(0.2, 1, 2, 3);
+            var oldCluster = CreateClusterWithPolicy(0.2, 1, 2);
+            var newCluster = CreateClusterWithPolicy(0.2, 1, 2);
 
             // Act
             var changeSet = ClusterChanges.GenerateChanges(oldCluster, newCluster, _loggerMock.Object);
@@ -32,8 +32,8 @@ namespace KustoSchemaTools.Tests.Changes
         public void GenerateChanges_WithSingleChange_ShouldDetectChangeAndCreateScript()
         {
             // Arrange
-            var oldCluster = CreateClusterWithPolicy(0.2, 1, 2, 3);
-            var newCluster = CreateClusterWithPolicy(0.2, 1, 2, 5);
+            var oldCluster = CreateClusterWithPolicy(0.2, 1, 2);
+            var newCluster = CreateClusterWithPolicy(0.2, 1, 5);
 
             // Act
             var changeSet = ClusterChanges.GenerateChanges(oldCluster, newCluster, _loggerMock.Object);
@@ -93,8 +93,7 @@ namespace KustoSchemaTools.Tests.Changes
         private Cluster CreateClusterWithPolicy(
             double? ingestionCapacityCoreUtilizationCoefficient = null,
             int? materializedViewsCapacityClusterMaximumConcurrentOperations = null,
-            int? extentsRebuildClusterMaximumConcurrentOperations = null,
-            int? extentsRebuildMaximumConcurrentOperationsPerNode = null
+            int? materializedViewsCapacityClusterMinimumConcurrentOperations = null
         )
         {
             return new Cluster
@@ -104,11 +103,7 @@ namespace KustoSchemaTools.Tests.Changes
                     MaterializedViewsCapacity = new MaterializedViewsCapacity
                     {
                         ClusterMaximumConcurrentOperations = materializedViewsCapacityClusterMaximumConcurrentOperations,
-                        ExtentsRebuildCapacity = (extentsRebuildClusterMaximumConcurrentOperations != null || extentsRebuildMaximumConcurrentOperationsPerNode != null) ? new ExtentsRebuildCapacity
-                        {
-                            ClusterMaximumConcurrentOperations = extentsRebuildClusterMaximumConcurrentOperations,
-                            MaximumConcurrentOperationsPerNode = extentsRebuildMaximumConcurrentOperationsPerNode
-                        } : null
+                        ClusterMinimumConcurrentOperations = materializedViewsCapacityClusterMinimumConcurrentOperations
                     },
                     IngestionCapacity = new IngestionCapacity
                     {

--- a/KustoSchemaTools.Tests/KustoClusterOrchestratorTests.cs
+++ b/KustoSchemaTools.Tests/KustoClusterOrchestratorTests.cs
@@ -3,13 +3,6 @@ using KustoSchemaTools.Model;
 using KustoSchemaTools.Parser;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Xunit;
-using System.Data;
-using System;
-using System.Linq;
 using Kusto.Data.Common;
 
 namespace KustoSchemaTools.Tests
@@ -28,10 +21,9 @@ namespace KustoSchemaTools.Tests
             kustoClusterHandlerFactoryMock = new Mock<IKustoClusterHandlerFactory>();
             yamlClusterHandlerFactoryMock = new Mock<IYamlClusterHandlerFactory>();
             
-            // Create mock for KustoClusterHandler
-            var kustoClientMock = new Mock<KustoClient>("test.eastus");
+            var adminClientMock = new Mock<ICslAdminProvider>();
             var kustoLoggerMock = new Mock<ILogger<KustoClusterHandler>>();
-            kustoHandlerMock = new Mock<KustoClusterHandler>(kustoClientMock.Object, kustoLoggerMock.Object, "test", "test.eastus");
+            kustoHandlerMock = new Mock<KustoClusterHandler>(adminClientMock.Object, kustoLoggerMock.Object, "test", "test.eastus");
             
             orchestrator = new KustoClusterOrchestrator(
                 loggerMock.Object,
@@ -57,12 +49,10 @@ namespace KustoSchemaTools.Tests
 
         private void SetupMockHandler(Cluster kustoCluster)
         {
-            // Configure the handler factory to return our mock handler
             kustoClusterHandlerFactoryMock
                 .Setup(f => f.Create("test", "test.eastus"))
                 .Returns(kustoHandlerMock.Object);
                 
-            // Set up the mock handler to return our test cluster
             kustoHandlerMock
                 .Setup(h => h.LoadAsync())
                 .ReturnsAsync(kustoCluster);
@@ -106,8 +96,7 @@ namespace KustoSchemaTools.Tests
 
         private void SetupMultipleClusterMocks()
         {
-            // Mock for cluster1
-            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("cluster1.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "cluster1", "cluster1.eastus");
+            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "cluster1", "cluster1.eastus");
             var kustoCluster1 = new Cluster
             {
                 Name = "cluster1",
@@ -128,8 +117,7 @@ namespace KustoSchemaTools.Tests
                 .Setup(h => h.LoadAsync())
                 .ReturnsAsync(kustoCluster1);
 
-            // Mock for cluster2 - same as config, no changes
-            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("cluster2.westus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "cluster2", "cluster2.westus");
+            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "cluster2", "cluster2.westus");
             var kustoCluster2 = new Cluster
             {
                 Name = "cluster2",
@@ -404,7 +392,7 @@ namespace KustoSchemaTools.Tests
                 .Returns(new YamlClusterHandler(yamlFilePath));
             
             // Set up mocks for the clusters defined in the YAML file
-            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("test1.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
+            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
             var kustoCluster1 = new Cluster
             {
                 Name = "test1",
@@ -425,7 +413,7 @@ namespace KustoSchemaTools.Tests
                 .Setup(h => h.LoadAsync())
                 .ReturnsAsync(kustoCluster1);
 
-            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("test2.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test2", "test2.eastus");
+            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test2", "test2.eastus");
             var kustoCluster2 = new Cluster
             {
                 Name = "test2",
@@ -568,8 +556,8 @@ namespace KustoSchemaTools.Tests
                 .Returns(new YamlClusterHandler(yamlFilePath));
             
             // Set up a simple mock for the clusters
-            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("test1.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
-            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("test2.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test2", "test2.eastus");
+            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
+            var kustoHandler2Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test2", "test2.eastus");
             
             kustoClusterHandlerFactoryMock
                 .Setup(f => f.Create("test1", "test1.eastus"))
@@ -639,7 +627,7 @@ namespace KustoSchemaTools.Tests
                 .Setup(f => f.Create(yamlFilePath))
                 .Returns(new YamlClusterHandler(yamlFilePath));
             
-            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<KustoClient>("test1.eastus").Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
+            var kustoHandler1Mock = new Mock<KustoClusterHandler>(new Mock<ICslAdminProvider>().Object, new Mock<ILogger<KustoClusterHandler>>().Object, "test1", "test1.eastus");
             
             kustoClusterHandlerFactoryMock
                 .Setup(f => f.Create("test1", "test1.eastus"))

--- a/KustoSchemaTools.Tests/Parser/KustoClusterHandlerTests.cs
+++ b/KustoSchemaTools.Tests/Parser/KustoClusterHandlerTests.cs
@@ -1,0 +1,390 @@
+using KustoSchemaTools.Changes;
+using KustoSchemaTools.Model;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Kusto.Data.Common;
+using System.Data;
+
+namespace KustoSchemaTools.Tests.Parser
+{
+    public class KustoClusterHandlerTests
+    {
+        private readonly Mock<ILogger<KustoClusterHandler>> _loggerMock;
+        private readonly Mock<ICslAdminProvider> _adminClientMock;
+        private readonly KustoClusterHandler _handler;
+
+        public KustoClusterHandlerTests()
+        {
+            _loggerMock = new Mock<ILogger<KustoClusterHandler>>();
+            _adminClientMock = new Mock<ICslAdminProvider>();
+            
+            _handler = new KustoClusterHandler(
+                _adminClientMock.Object,
+                _loggerMock.Object,
+                "test-cluster",
+                "test.eastus"
+            );
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithEmptyChangeSet_ReturnsEmptyResult()
+        {
+            // Arrange
+            var changeSet = new ClusterChangeSet("test-cluster", new Cluster(), new Cluster());
+            
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+            
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+            
+            // Verify no commands were executed
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ClientRequestProperties>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithInvalidScripts_SkipsInvalidScripts()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", 0, ".alter cluster policy capacity", false) { IsValid = false },
+                new DatabaseScriptContainer("policy", 1, ".show cluster policy capacity", false) { IsValid = true }
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            
+            // Verify only valid scripts were included in the execution
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.Is<string>(cmd => cmd.Contains(".show cluster policy capacity") && !cmd.Contains(".alter cluster policy capacity")),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithNegativeOrderScripts_SkipsNegativeOrderScripts()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", -1, ".alter cluster policy capacity", false) { IsValid = true },
+                new DatabaseScriptContainer("policy", 0, ".show cluster policy capacity", false) { IsValid = true }
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            
+            // Verify negative order scripts were excluded
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.Is<string>(cmd => cmd.Contains(".show cluster policy capacity") && !cmd.Contains(".alter cluster policy capacity")),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithMultipleValidScripts_ExecutesInCorrectOrder()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", 2, ".alter cluster policy capacity script2", false) { IsValid = true },
+                new DatabaseScriptContainer("policy", 0, ".alter cluster policy capacity script0", false) { IsValid = true },
+                new DatabaseScriptContainer("policy", 1, ".alter cluster policy capacity script1", false) { IsValid = true }
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            
+            // Verify scripts were executed in order (script0, script1, script2)
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.Is<string>(cmd => 
+                    cmd.Contains("script0") && 
+                    cmd.Contains("script1") && 
+                    cmd.Contains("script2") &&
+                    cmd.IndexOf("script0") < cmd.IndexOf("script1") &&
+                    cmd.IndexOf("script1") < cmd.IndexOf("script2")),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithValidScripts_GeneratesCorrectClusterScript()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", 0, ".alter cluster policy capacity", false) { IsValid = true },
+                new DatabaseScriptContainer("policy", 1, ".show cluster policy capacity", false) { IsValid = true }
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            
+            // Verify the correct cluster script format was generated
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.Is<string>(cmd => 
+                    cmd.StartsWith(".execute cluster script with(ContinueOnErrors = true) <|") &&
+                    cmd.Contains(".alter cluster policy capacity") &&
+                    cmd.Contains(".show cluster policy capacity")),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WriteAsync_WithMixedValidityAndOrder_FiltersCorrectly()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", -1, "script1", false) { IsValid = true }, // Filtered out (negative order)
+                new DatabaseScriptContainer("policy", 0, "script2", false) { IsValid = false }, // Filtered out (invalid)
+                new DatabaseScriptContainer("policy", 1, "script3", false) { IsValid = true }, // Should be included
+                new DatabaseScriptContainer("policy", 2, "script4", false) { IsValid = null }, // Filtered out (not explicitly valid)
+                new DatabaseScriptContainer("policy", 3, "script5", false) { IsValid = true }  // Should be included
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            
+            // Verify only script3 and script5 were included
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.Is<string>(cmd => 
+                    cmd.Contains("script3") &&
+                    cmd.Contains("script5") &&
+                    !cmd.Contains("script1") &&
+                    !cmd.Contains("script2") &&
+                    !cmd.Contains("script4")),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WriteAsync_CallsExecuteControlCommandAsync()
+        {
+            // Arrange
+            var changeSet = CreateChangeSetWithScripts(new[]
+            {
+                new DatabaseScriptContainer("policy", 0, ".alter cluster policy capacity", false) { IsValid = true }
+            });
+
+            var mockResult = CreateMockDataReader();
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", It.IsAny<string>(), It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockResult.Object);
+
+            // Act
+            var result = await _handler.WriteAsync(changeSet);
+
+            // Assert
+            Assert.NotNull(result);
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                It.IsAny<string>(),
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WithCapacityPolicy_ReturnsClusterWithPolicy()
+        {
+            // Arrange
+            var policyJson = """
+            {
+                "IngestionCapacity": {
+                    "ClusterMaximumConcurrentOperations": 500,
+                    "CoreUtilizationCoefficient": 0.75
+                },
+                "MaterializedViewsCapacity": {
+                    "ClusterMinimumConcurrentOperations": 10,
+                    "ClusterMaximumConcurrentOperations": 100
+                },
+                "MirroringCapacity": {
+                    "ClusterMaximumConcurrentOperations": 50
+                }
+            }
+            """;
+
+            var mockReader = new Mock<IDataReader>();
+            mockReader.SetupSequence(x => x.Read())
+                .Returns(true)   // First call returns true (data available)
+                .Returns(false); // Second call returns false (no more data)
+            mockReader.Setup(x => x["Policy"]).Returns(policyJson);
+
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", ".show cluster policy capacity", It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockReader.Object);
+
+            // Act
+            var result = await _handler.LoadAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("test-cluster", result.Name);
+            Assert.Equal("test.eastus", result.Url);
+            Assert.NotNull(result.CapacityPolicy);
+            
+            Assert.NotNull(result.CapacityPolicy.IngestionCapacity);
+            Assert.Equal(500, result.CapacityPolicy.IngestionCapacity.ClusterMaximumConcurrentOperations);
+            Assert.Equal(0.75, result.CapacityPolicy.IngestionCapacity.CoreUtilizationCoefficient);
+
+            Assert.NotNull(result.CapacityPolicy.MaterializedViewsCapacity);
+            Assert.Equal(10, result.CapacityPolicy.MaterializedViewsCapacity.ClusterMinimumConcurrentOperations);
+            Assert.Equal(100, result.CapacityPolicy.MaterializedViewsCapacity.ClusterMaximumConcurrentOperations);
+
+            Assert.NotNull(result.CapacityPolicy.MirroringCapacity);
+            Assert.Equal(50, result.CapacityPolicy.MirroringCapacity.ClusterMaximumConcurrentOperations);
+
+            // Verify the correct command was executed
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                ".show cluster policy capacity",
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WithNoPolicyData_ReturnsClusterWithoutPolicy()
+        {
+            // Arrange
+            var mockReader = new Mock<IDataReader>();
+            mockReader.Setup(x => x.Read()).Returns(false); // No data
+
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", ".show cluster policy capacity", It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockReader.Object);
+
+            // Act
+            var result = await _handler.LoadAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("test-cluster", result.Name);
+            Assert.Equal("test.eastus", result.Url);
+            Assert.Null(result.CapacityPolicy);
+
+            // Verify the correct command was executed
+            _adminClientMock.Verify(x => x.ExecuteControlCommandAsync(
+                "",
+                ".show cluster policy capacity",
+                It.IsAny<ClientRequestProperties>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WithEmptyPolicyJson_ReturnsClusterWithoutPolicy()
+        {
+            // Arrange
+            var mockReader = new Mock<IDataReader>();
+            mockReader.SetupSequence(x => x.Read())
+                .Returns(true)   // First call returns true (data available)
+                .Returns(false); // Second call returns false (no more data)
+            mockReader.Setup(x => x["Policy"]).Returns(""); // Empty policy
+
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", ".show cluster policy capacity", It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockReader.Object);
+
+            // Act
+            var result = await _handler.LoadAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("test-cluster", result.Name);
+            Assert.Equal("test.eastus", result.Url);
+            Assert.Null(result.CapacityPolicy);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WithNullPolicyJson_ReturnsClusterWithoutPolicy()
+        {
+            // Arrange
+            var mockReader = new Mock<IDataReader>();
+            mockReader.SetupSequence(x => x.Read())
+                .Returns(true)   // First call returns true (data available)
+                .Returns(false); // Second call returns false (no more data)
+            mockReader.Setup(x => x["Policy"]).Returns((object?)null); // Null policy
+
+            _adminClientMock
+                .Setup(x => x.ExecuteControlCommandAsync("", ".show cluster policy capacity", It.IsAny<ClientRequestProperties>()))
+                .ReturnsAsync(mockReader.Object);
+
+            // Act
+            var result = await _handler.LoadAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("test-cluster", result.Name);
+            Assert.Equal("test.eastus", result.Url);
+            Assert.Null(result.CapacityPolicy);
+        }
+
+        #region Helper Methods
+
+        private ClusterChangeSet CreateChangeSetWithScripts(DatabaseScriptContainer[] scripts)
+        {
+            var changeSet = new ClusterChangeSet("test-cluster", new Cluster(), new Cluster());
+            
+            // Create a mock change that contains the scripts
+            var mockChange = new Mock<IChange>();
+            mockChange.Setup(x => x.Scripts).Returns(scripts.ToList());
+            
+            changeSet.Changes.Add(mockChange.Object);
+            
+            return changeSet;
+        }
+
+        private Mock<IDataReader> CreateMockDataReader()
+        {
+            var mockReader = new Mock<IDataReader>();
+            
+            // Make Read() return false to simulate no data
+            mockReader.Setup(x => x.Read()).Returns(false);
+
+            return mockReader;
+        }
+
+        #endregion
+    }
+}

--- a/KustoSchemaTools/KustoClusterOrchestrator.cs
+++ b/KustoSchemaTools/KustoClusterOrchestrator.cs
@@ -2,6 +2,7 @@ using KustoSchemaTools.Changes;
 using KustoSchemaTools.Model;
 using KustoSchemaTools.Parser;
 using Microsoft.Extensions.Logging;
+using Kusto.Data;
 
 namespace KustoSchemaTools
 {
@@ -64,6 +65,45 @@ namespace KustoSchemaTools
             Log.LogInformation($"Loaded {clusterList.Count} cluster configuration(s) from YAML file");
 
             return await GenerateChangesAsync(clusters);
+        }
+
+        /// <summary>
+        /// Loads cluster configurations from a YAML file, generates changes by comparing 
+        /// them with the live Kusto clusters, and then applies those changes.
+        /// </summary>
+        /// <param name="clusterConfigFilePath">The path to the YAML file containing cluster configurations.</param>
+        /// <returns>A task representing the asynchronous apply operation.</returns>
+        public async Task<List<ScriptExecuteCommandResult>> ApplyAsync(string clusterConfigFilePath)
+        {
+            Log.LogInformation($"Starting apply operation for cluster config file: {clusterConfigFilePath}");
+
+            // Generate the changes first
+            var changeSets = await GenerateChangesFromFileAsync(clusterConfigFilePath);
+            var allResults = new List<ScriptExecuteCommandResult>();
+
+            if (!changeSets.Any(cs => cs.Changes.SelectMany(itm => itm.Scripts).Where(itm => itm.Order >= 0).Where(itm => itm.IsValid == true).Any()))
+            {
+                Log.LogInformation("No changes detected to apply.");
+                return allResults;
+            }
+
+            // Apply changes for each cluster
+            foreach (var changeSet in changeSets.Where(cs => cs.Changes.SelectMany(itm => itm.Scripts).Where(itm => itm.Order >= 0).Where(itm => itm.IsValid == true).Any()))
+            {
+                Log.LogInformation($"Applying changes to cluster: {changeSet.Entity}");
+
+                var clusterName = changeSet.To.Name;
+                var clusterUrl = changeSet.To.Url;
+
+                var kustoHandler = KustoClusterHandlerFactory.Create(clusterName, clusterUrl);
+                var result = await kustoHandler.WriteAsync(changeSet);
+                
+                // Add the results from this cluster to the overall results list
+                allResults.AddRange(result);
+            }
+
+            Log.LogInformation($"Finished applying. Total scripts executed: {allResults.Count}");
+            return allResults;
         }
     }
 }

--- a/KustoSchemaTools/KustoClusterOrchestrator.cs
+++ b/KustoSchemaTools/KustoClusterOrchestrator.cs
@@ -86,6 +86,12 @@ namespace KustoSchemaTools
             {
                 Log.LogInformation($"Applying changes to cluster: {changeSet.Entity}");
 
+                if (changeSet.Changes.Count == 0)
+                {
+                    Log.LogInformation($"No changes to apply for cluster: {changeSet.Entity}");
+                    continue;
+                }
+
                 var clusterName = changeSet.To.Name;
                 var clusterUrl = changeSet.To.Url;
 

--- a/KustoSchemaTools/KustoClusterOrchestrator.cs
+++ b/KustoSchemaTools/KustoClusterOrchestrator.cs
@@ -81,14 +81,8 @@ namespace KustoSchemaTools
             var changeSets = await GenerateChangesFromFileAsync(clusterConfigFilePath);
             var allResults = new List<ScriptExecuteCommandResult>();
 
-            if (!changeSets.Any(cs => cs.Changes.SelectMany(itm => itm.Scripts).Where(itm => itm.Order >= 0).Where(itm => itm.IsValid == true).Any()))
-            {
-                Log.LogInformation("No changes detected to apply.");
-                return allResults;
-            }
-
             // Apply changes for each cluster
-            foreach (var changeSet in changeSets.Where(cs => cs.Changes.SelectMany(itm => itm.Scripts).Where(itm => itm.Order >= 0).Where(itm => itm.IsValid == true).Any()))
+            foreach (var changeSet in changeSets)
             {
                 Log.LogInformation($"Applying changes to cluster: {changeSet.Entity}");
 

--- a/KustoSchemaTools/Model/ClusterCapacityPolicy.cs
+++ b/KustoSchemaTools/Model/ClusterCapacityPolicy.cs
@@ -19,6 +19,7 @@ namespace KustoSchemaTools.Model
         public StreamingIngestionPostProcessingCapacity? StreamingIngestionPostProcessingCapacity { get; set; }
         public PurgeStorageArtifactsCleanupCapacity? PurgeStorageArtifactsCleanupCapacity { get; set; }
         public PeriodicStorageArtifactsCleanupCapacity? PeriodicStorageArtifactsCleanupCapacity { get; set; }
+        public MirroringCapacity? MirroringCapacity { get; set; }
         public QueryAccelerationCapacity? QueryAccelerationCapacity { get; set; }
         public GraphSnapshotsCapacity? GraphSnapshotsCapacity { get; set; }
 
@@ -37,6 +38,7 @@ namespace KustoSchemaTools.Model
                 EqualityComparer<StreamingIngestionPostProcessingCapacity?>.Default.Equals(StreamingIngestionPostProcessingCapacity, other.StreamingIngestionPostProcessingCapacity) &&
                 EqualityComparer<PurgeStorageArtifactsCleanupCapacity?>.Default.Equals(PurgeStorageArtifactsCleanupCapacity, other.PurgeStorageArtifactsCleanupCapacity) &&
                 EqualityComparer<PeriodicStorageArtifactsCleanupCapacity?>.Default.Equals(PeriodicStorageArtifactsCleanupCapacity, other.PeriodicStorageArtifactsCleanupCapacity) &&
+                EqualityComparer<MirroringCapacity?>.Default.Equals(MirroringCapacity, other.MirroringCapacity) &&
                 EqualityComparer<QueryAccelerationCapacity?>.Default.Equals(QueryAccelerationCapacity, other.QueryAccelerationCapacity) &&
                 EqualityComparer<GraphSnapshotsCapacity?>.Default.Equals(GraphSnapshotsCapacity, other.GraphSnapshotsCapacity);
         }
@@ -55,6 +57,7 @@ namespace KustoSchemaTools.Model
             hc.Add(StreamingIngestionPostProcessingCapacity);
             hc.Add(PurgeStorageArtifactsCleanupCapacity);
             hc.Add(PeriodicStorageArtifactsCleanupCapacity);
+            hc.Add(MirroringCapacity);
             hc.Add(QueryAccelerationCapacity);
             hc.Add(GraphSnapshotsCapacity);
             return hc.ToHashCode();
@@ -192,40 +195,17 @@ namespace KustoSchemaTools.Model
 
     public class MaterializedViewsCapacity : IEquatable<MaterializedViewsCapacity>
     {
+        public int? ClusterMinimumConcurrentOperations { get; set; }
         public int? ClusterMaximumConcurrentOperations { get; set; }
-        public ExtentsRebuildCapacity? ExtentsRebuildCapacity { get; set; }
 
         public bool Equals(MaterializedViewsCapacity? other)
         {
             if (other is null) return false;
-            return ClusterMaximumConcurrentOperations == other.ClusterMaximumConcurrentOperations &&
-                   EqualityComparer<ExtentsRebuildCapacity?>.Default.Equals(ExtentsRebuildCapacity, other.ExtentsRebuildCapacity);
+            return ClusterMinimumConcurrentOperations == other.ClusterMinimumConcurrentOperations &&
+                   ClusterMaximumConcurrentOperations == other.ClusterMaximumConcurrentOperations;
         }
         public override bool Equals(object? obj) => Equals(obj as MaterializedViewsCapacity);
-        public override int GetHashCode() => HashCode.Combine(ClusterMaximumConcurrentOperations, ExtentsRebuildCapacity);
-        public override string ToString()
-        {
-            return JsonConvert.SerializeObject(this, new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                Formatting = Formatting.None
-            });
-        }
-    }
-
-    public class ExtentsRebuildCapacity : IEquatable<ExtentsRebuildCapacity>
-    {
-        public int? ClusterMaximumConcurrentOperations { get; set; }
-        public int? MaximumConcurrentOperationsPerNode { get; set; }
-
-        public bool Equals(ExtentsRebuildCapacity? other)
-        {
-            if (other is null) return false;
-            return ClusterMaximumConcurrentOperations == other.ClusterMaximumConcurrentOperations &&
-                   MaximumConcurrentOperationsPerNode == other.MaximumConcurrentOperationsPerNode;
-        }
-        public override bool Equals(object? obj) => Equals(obj as ExtentsRebuildCapacity);
-        public override int GetHashCode() => HashCode.Combine(ClusterMaximumConcurrentOperations, MaximumConcurrentOperationsPerNode);
+        public override int GetHashCode() => HashCode.Combine(ClusterMinimumConcurrentOperations, ClusterMaximumConcurrentOperations);
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this, new JsonSerializerSettings
@@ -312,6 +292,29 @@ namespace KustoSchemaTools.Model
         }
         public override bool Equals(object? obj) => Equals(obj as PeriodicStorageArtifactsCleanupCapacity);
         public override int GetHashCode() => HashCode.Combine(MaximumConcurrentOperationsPerCluster);
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Formatting = Formatting.None
+            });
+        }
+    }
+
+    public class MirroringCapacity : IEquatable<MirroringCapacity>
+    {
+        public int? ClusterMaximumConcurrentOperations { get; set; }
+        public double? CoreUtilizationCoefficient { get; set; }
+
+        public bool Equals(MirroringCapacity? other)
+        {
+            if (other is null) return false;
+            return ClusterMaximumConcurrentOperations == other.ClusterMaximumConcurrentOperations &&
+                   CoreUtilizationCoefficient == other.CoreUtilizationCoefficient;
+        }
+        public override bool Equals(object? obj) => Equals(obj as MirroringCapacity);
+        public override int GetHashCode() => HashCode.Combine(ClusterMaximumConcurrentOperations, CoreUtilizationCoefficient);
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this, new JsonSerializerSettings

--- a/KustoSchemaTools/Parser/KustoClusterHandler.cs
+++ b/KustoSchemaTools/Parser/KustoClusterHandler.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json;
 using KustoSchemaTools.Parser;
 using KustoSchemaTools.Changes;
 using Kusto.Data;
-using System.Text;
 
 namespace KustoSchemaTools
 {
@@ -18,10 +17,10 @@ namespace KustoSchemaTools
 
         public KustoClusterHandler(ICslAdminProvider adminClient, ILogger<KustoClusterHandler> logger, string clusterName, string clusterUrl)
         {
-            _adminClient = adminClient ?? throw new ArgumentNullException(nameof(adminClient));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _clusterName = clusterName ?? throw new ArgumentNullException(nameof(clusterName));
-            _clusterUrl = clusterUrl ?? throw new ArgumentNullException(nameof(clusterUrl));
+            _adminClient = adminClient;
+            _logger = logger;
+            _clusterName = clusterName;
+            _clusterUrl = clusterUrl;
         }
 
         public virtual async Task<Cluster> LoadAsync()

--- a/KustoSchemaTools/Parser/KustoClusterHandler.cs
+++ b/KustoSchemaTools/Parser/KustoClusterHandler.cs
@@ -63,6 +63,7 @@ namespace KustoSchemaTools
         {
             if (scripts.Count == 0)
             {
+                _logger.LogInformation("No scripts to execute.");
                 return new List<ScriptExecuteCommandResult>();
             }
 

--- a/KustoSchemaTools/Parser/KustoClusterHandler.cs
+++ b/KustoSchemaTools/Parser/KustoClusterHandler.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Logging;
 using Kusto.Data.Common;
 using Newtonsoft.Json;
 using KustoSchemaTools.Parser;
+using KustoSchemaTools.Changes;
+using Kusto.Data;
 
 namespace KustoSchemaTools
 {
@@ -41,6 +43,58 @@ namespace KustoSchemaTools
             }
 
             return cluster;
+        }
+
+        public virtual async Task<List<ScriptExecuteCommandResult>> WriteAsync(ClusterChangeSet changeSet)
+        {
+            var scripts = changeSet.Changes
+                .SelectMany(itm => itm.Scripts)
+                .Where(itm => itm.Order >= 0)
+                .Where(itm => itm.IsValid == true)
+                .OrderBy(itm => itm.Order)
+                .ToList();
+
+            var results = new List<ScriptExecuteCommandResult>();
+
+            foreach (var script in scripts)
+            {
+                var asyncResult = await ExecuteAsyncCommand(script.Text);
+                results.Add(asyncResult);
+            }
+
+            return results;
+        }
+
+        private async Task<ScriptExecuteCommandResult> ExecuteAsyncCommand(string scriptText)
+        {
+            var interval = TimeSpan.FromSeconds(5);
+            var iterations = (int)(TimeSpan.FromHours(1) / interval);
+            var result = await _client.AdminClient.ExecuteControlCommandAsync("", scriptText);
+            var operationId = result.ToScalar<Guid>();
+            var finalState = false;
+            string monitoringCommand = $".show operations | where OperationId ==  '{operationId}' " +
+                "| summarize arg_max(LastUpdatedOn, *) by OperationId " +
+                "| project OperationId, CommandType = Operation, Result = State, Reason = Status";
+            int cnt = 0;
+            while (!finalState)
+            {
+                if (cnt++ >= iterations)
+                {
+                    finalState = true;
+                }
+
+                _logger.LogInformation($"Waiting for operation {operationId} to complete... current iteration: {cnt}/{iterations}");
+                var monitoringResult = _client.Client.ExecuteQuery(monitoringCommand, new ClientRequestProperties());
+                var operationState = monitoringResult.As<ScriptExecuteCommandResult>().FirstOrDefault();
+
+                if (operationState != null && operationState?.IsFinal() == true)
+                {
+                    operationState.CommandText = scriptText;
+                    return operationState;
+                }
+                await Task.Delay(interval);
+            }
+            throw new Exception("Operation did not complete in a reasonable time");
         }
     }
 }

--- a/KustoSchemaTools/Parser/KustoClusterHandler.cs
+++ b/KustoSchemaTools/Parser/KustoClusterHandler.cs
@@ -11,17 +11,17 @@ namespace KustoSchemaTools
 {
     public class KustoClusterHandler
     {
-        private readonly KustoClient _client;
+        private readonly ICslAdminProvider _adminClient;
         private readonly ILogger<KustoClusterHandler> _logger;
         private readonly string _clusterName;
         private readonly string _clusterUrl;
 
-        public KustoClusterHandler(KustoClient client, ILogger<KustoClusterHandler> logger, string clusterName, string clusterUrl)
+        public KustoClusterHandler(ICslAdminProvider adminClient, ILogger<KustoClusterHandler> logger, string clusterName, string clusterUrl)
         {
-            _client = client;
-            _logger = logger;
-            _clusterName = clusterName;
-            _clusterUrl = clusterUrl;
+            _adminClient = adminClient ?? throw new ArgumentNullException(nameof(adminClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _clusterName = clusterName ?? throw new ArgumentNullException(nameof(clusterName));
+            _clusterUrl = clusterUrl ?? throw new ArgumentNullException(nameof(clusterUrl));
         }
 
         public virtual async Task<Cluster> LoadAsync()
@@ -30,7 +30,7 @@ namespace KustoSchemaTools
 
             _logger.LogInformation("Loading cluster capacity policy...");
 
-            using (var reader = await _client.AdminClient.ExecuteControlCommandAsync("", ".show cluster policy capacity", new ClientRequestProperties()))
+            using (var reader = await _adminClient.ExecuteControlCommandAsync("", ".show cluster policy capacity", new ClientRequestProperties()))
             {
                 if (reader.Read())
                 {
@@ -72,7 +72,7 @@ namespace KustoSchemaTools
 
             _logger.LogInformation($"Applying cluster script:\n{script}");
             
-            var result = await _client.AdminClient.ExecuteControlCommandAsync("", script);
+            var result = await _adminClient.ExecuteControlCommandAsync("", script);
             return result.As<ScriptExecuteCommandResult>();
         }
     }

--- a/KustoSchemaTools/Parser/KustoClusterHandlerFactory.cs
+++ b/KustoSchemaTools/Parser/KustoClusterHandlerFactory.cs
@@ -16,7 +16,7 @@ namespace KustoSchemaTools
         {
             var client = new KustoClient(clusterUrl);
             var logger = _loggerFactory.CreateLogger<KustoClusterHandler>();
-            return new KustoClusterHandler(client, logger, clusterName, clusterUrl);
+            return new KustoClusterHandler(client.AdminClient, logger, clusterName, clusterUrl);
         }
     }
 }

--- a/KustoSchemaTools/Parser/YamlClusterHandlerFactory.cs
+++ b/KustoSchemaTools/Parser/YamlClusterHandlerFactory.cs
@@ -1,6 +1,8 @@
+using KustoSchemaTools.Parser;
+
 namespace KustoSchemaTools
 {
-    public class YamlClusterHandlerFactory
+    public class YamlClusterHandlerFactory : IYamlClusterHandlerFactory
     {
         public virtual YamlClusterHandler Create(string path)
         {


### PR DESCRIPTION
## Overview

This pull request implements the apply() method for cluster configuration changes.
This PR is a follow-up to #106

https://github.com/github/data/issues/9010

## Changes
* Implements `ApplyAsync()` which diffs then executes cluster configuration changes
* Adds functionality to KustoClusterHandler to execute cluster scripts 
* Refactors the KustoClusterHandler for better testability
* Updates the ClusterCapacityPolicy model to have parity with the model returned by `.show cluster policy capacity`
  * When I created this model I was referencing the properties from the [Microsoft docs](https://github.com/github/KustoSchemaTools/pull/106), but the docs seem to be slightly out of sync with the actual model returned from Kusto

