### PR TITLE
Add retries to DatabaseWriter and unit tests

### DIFF
--- a/KustoSchemaTools.Tests/DefaultDatabaseWriterTests.cs
+++ b/KustoSchemaTools.Tests/DefaultDatabaseWriterTests.cs
@@ -1,0 +1,230 @@
+using Kusto.Data;
+using KustoSchemaTools.Changes;
+using KustoSchemaTools.Model;
+using KustoSchemaTools.Parser;
+using KustoSchemaTools.Parser.KustoWriter;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace KustoSchemaTools.Tests
+{
+    public class DefaultDatabaseWriterTests
+    {
+        [Fact]
+        public async Task UpdatePrimary_ShouldRetryUntilChangesSucceed()
+        {
+            // Arrange
+            var sourceDb = new Database { Name = "SourceDb" };
+            var targetDb = new Database { Name = "TargetDb" };
+
+            var logger = new ConsoleLogger();
+            var mockClient = new Mock<KustoClient>(MockBehavior.Loose, "test");
+
+            var writer = new TestableDefaultDatabaseWriter();
+
+            // Create mock changes for the test
+            writer.Setup(true, false, false);
+            writer.Setup(true, true);
+
+            // Act
+            await writer.WriteAsync(sourceDb, targetDb, mockClient.Object, logger);
+            Assert.Equal(2, writer.GenerateChangesCallCount);
+            Assert.Equal(2, writer.ApplyChangesToDatabaseCallCount);
+            Assert.Equal(0, writer.ExceptionCount);
+        }
+
+        [Fact]
+        public async Task UpdatePrimary_NoRetryIfAllSucces()
+        {
+            // Arrange
+            var sourceDb = new Database { Name = "SourceDb" };
+            var targetDb = new Database { Name = "TargetDb" };
+            var logger = new ConsoleLogger();
+            var mockClient = new Mock<KustoClient>(MockBehavior.Loose, "test");
+            var writer = new TestableDefaultDatabaseWriter();
+
+            // Create mock changesets for the test
+            writer.Setup(true, true, true);
+            writer.Setup(true, true, true);
+
+            // all success
+            await writer.WriteAsync(sourceDb, targetDb, mockClient.Object, logger);
+            Assert.Equal(1, writer.GenerateChangesCallCount);
+            Assert.Equal(1, writer.ApplyChangesToDatabaseCallCount);
+            Assert.Equal(0, writer.ExceptionCount);
+        }
+
+        [Fact]
+        public async Task UpdatePrimary_NoRetryIfAllFail()
+        {
+            // Arrange
+            var sourceDb = new Database { Name = "SourceDb" };
+            var targetDb = new Database { Name = "TargetDb" };
+            var logger = new ConsoleLogger();
+            var mockClient = new Mock<KustoClient>(MockBehavior.Loose, "test");
+            var writer = new TestableDefaultDatabaseWriter();
+
+            // Create mock changesets for the test
+            writer.Setup(false, false, false);
+            writer.Setup(false, false, false);
+
+            await writer.WriteAsync(sourceDb, targetDb, mockClient.Object, logger);
+            Assert.Equal(1, writer.GenerateChangesCallCount);
+            Assert.Equal(1, writer.ApplyChangesToDatabaseCallCount);
+            Assert.Equal(1, writer.ExceptionCount);
+        }
+
+
+        [Fact]
+        public async Task UpdatePrimary_ShouldRetryUntilNoSuccessfulChanges()
+        {
+            // Arrange
+            var sourceDb = new Database { Name = "SourceDb" };
+            var targetDb = new Database { Name = "TargetDb" };
+            var logger = new ConsoleLogger();
+            var mockClient = new Mock<KustoClient>(MockBehavior.Loose, "test");
+            var writer = new TestableDefaultDatabaseWriter();
+
+            // Create mock changes for the test
+            writer.Setup(true, false, false);
+            writer.Setup(true, false);
+            writer.Setup(false);
+            writer.Setup(false); // one extra
+
+            // Act
+            await writer.WriteAsync(sourceDb, targetDb, mockClient.Object, logger);
+            Assert.Equal(3, writer.GenerateChangesCallCount);
+            Assert.Equal(3, writer.ApplyChangesToDatabaseCallCount);
+            Assert.Equal(1, writer.ExceptionCount);
+        }
+
+        #region Helper Methods
+
+
+        static IChange CreateMockChange(string name)
+        {
+            var mockChange = new Mock<IChange>();
+
+            var scripts = new List<DatabaseScriptContainer> {
+                new DatabaseScriptContainer(
+                    new DatabaseScript(name, 0),
+                    "TestKind"
+                )
+            };
+
+            mockChange.Setup(c => c.Scripts).Returns(scripts);
+            return mockChange.Object;
+        }
+
+        static ScriptExecuteCommandResult CreateMockResult(IChange change, bool isSuccess)
+        {
+            return new ScriptExecuteCommandResult {
+                OperationId = Guid.NewGuid(),
+                CommandType = "Script",
+                Result = isSuccess ? "Completed" : "Failed",
+                CommandText = change.Scripts.First().Script.Text,
+                Reason = isSuccess ? null : "Test failure"
+            };
+        }
+
+        #endregion
+
+        #region Test Support Classes
+
+        /// <summary>
+        /// A testable version of DefaultDatabaseWriter that we can use to track calls and control behavior
+        /// </summary>
+        private class TestableDefaultDatabaseWriter : DefaultDatabaseWriter
+        {
+            public Dictionary<IChange, ScriptExecuteCommandResult> ResultsCache { get; } = new Dictionary<IChange, ScriptExecuteCommandResult>();
+            private readonly IList<List<IChange>> _generateChangesResults = new List<List<IChange>>();
+            public int GenerateChangesCallCount { get; private set; } = 0;
+            public int ApplyChangesToDatabaseCallCount { get; private set; } = 0;
+            public int ExceptionCount { get; private set; } = 0;
+
+            public void ResetCounts()
+            {
+                GenerateChangesCallCount = ApplyChangesToDatabaseCallCount = ExceptionCount = 0;
+            }
+
+            public void Setup(params bool[] results)
+            {
+                var changeSet = new List<IChange> { };
+                foreach (var result in results)
+                {
+                    var change = CreateMockChange($"change");
+                    var scriptExecuteResult = CreateMockResult(change, result);
+                    ResultsCache.Add(change, scriptExecuteResult);
+                    changeSet.Add(change);
+                }
+                _generateChangesResults.Add(changeSet);
+            }
+
+            // Override the base method to use our predetermined results
+            internal override List<IChange> GenerateChanges(Database targetDb, Database sourceDb, ILogger logger)
+            {
+                if (GenerateChangesCallCount >= _generateChangesResults.Count)
+                {
+                    throw new InvalidOperationException("No more predefined change sets available.");
+                }
+
+                var changes = _generateChangesResults.ElementAt(GenerateChangesCallCount);
+                GenerateChangesCallCount++;
+                return changes;
+            }
+
+            // Override the protected method to return our predetermined results
+            internal override Task<List<ScriptExecuteCommandResult>> ApplyChangesToDatabase(string databaseName, List<IChange> changes, KustoClient client, ILogger logger)
+            {
+                ApplyChangesToDatabaseCallCount++;
+                var results = new List<ScriptExecuteCommandResult>();
+                foreach (var c in changes) {
+                    var result = ResultsCache[c];
+                    results.Add(result);
+                }
+                return Task.FromResult(results);
+            }
+
+            // Expose the internal UpdatePrimary method for testing
+            public Task<List<ScriptExecuteCommandResult>> TestUpdatePrimary(Database sourceDb, Database targetDb, KustoClient client, ILogger logger)
+            {
+                return UpdatePrimary(sourceDb, targetDb, client, logger);
+            }
+
+            // Override WriteAsync to control exception throwing
+            public override async Task WriteAsync(Database sourceDb, Database targetDb, KustoClient client, ILogger logger)
+            {
+                try
+                {
+                    await base.WriteAsync(sourceDb, targetDb, client, logger);
+                }
+                catch (Exception)
+                {
+                    ExceptionCount++;
+                }
+            }
+        }
+
+        // Custom console logger implementation
+        private class ConsoleLogger : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => new DummyDisposable();
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                Console.WriteLine($"[{logLevel}] {formatter(state, exception)}");
+                if (exception != null)
+                {
+                    Console.WriteLine($"Exception: {exception.Message}");
+                }
+            }
+
+            private class DummyDisposable : IDisposable
+            {
+                public void Dispose() { }
+            }
+        }
+        #endregion
+    }
+}

--- a/KustoSchemaTools/Parser/KustoWriter/DefaultDatabaseWriter.cs
+++ b/KustoSchemaTools/Parser/KustoWriter/DefaultDatabaseWriter.cs
@@ -1,4 +1,4 @@
-﻿using Kusto.Data;
+using Kusto.Data;
 using KustoSchemaTools.Changes;
 using KustoSchemaTools.Model;
 using KustoSchemaTools.Parser.KustoLoader;
@@ -10,16 +10,71 @@ namespace KustoSchemaTools.Parser.KustoWriter
 {
     public class DefaultDatabaseWriter : IDBEntityWriter
     {
-        public async Task WriteAsync(Database sourceDb, Database targetDb, KustoClient client, ILogger logger)
+        public virtual async Task WriteAsync(Database sourceDb, Database targetDb, KustoClient client, ILogger logger)
         {
-            var changes = DatabaseChanges.GenerateChanges(targetDb, sourceDb, targetDb.Name, logger);
-            var results = await ApplyChangesToDatabase(targetDb.Name, changes, client, logger);
+            var allResults = await UpdatePrimary(sourceDb, targetDb, client, logger);
+            allResults.AddRange(await UpdateFollowers(sourceDb, logger));
 
-            foreach (var result in results)
+            // Throw exception if there were any problems.
+            var exceptions = allResults
+                .Where(itm => itm.Result == "Failed")
+                .Select(itm => new Exception($"Execution failed for command:{itm.OperationId} with reason: {itm.Reason}"))
+                .ToList();
+
+            if (exceptions.Count == 1)
+            {
+                throw exceptions[0];
+            }
+            if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        internal virtual async Task<List<ScriptExecuteCommandResult>> UpdatePrimary(Database sourceDb, Database targetDb, KustoClient client, ILogger logger)
+        {
+            // Some changes will be dependent upon each other, causing a race condition when attempting to apply them.
+            // As long as the write made some forward progress, keep looping until it stalls.
+            logger.LogInformation($"Updating primary database {targetDb.Name}");
+            var keepGoing = false;
+            var iterationCount = 0;
+            var allResults = new List<ScriptExecuteCommandResult>();
+
+            // Iteratively generate changes and apply them until we stop making forward progress.
+            do
+            {
+                iterationCount++;
+                var changes = GenerateChanges(targetDb, sourceDb, logger);
+                var results = await ApplyChangesToDatabase(targetDb.Name, changes, client, logger);
+
+                // Save the successes
+                var successes = results.Where(r => r.Result != "Failed").ToList();
+                allResults.AddRange(successes);
+                logger.LogInformation($"Iteration {iterationCount}: Successfully applied {successes.Count} out of {results.Count} changes.");
+
+                // Decide whether to loop
+                keepGoing = successes.Count < results.Count && successes.Count > 0;
+                if (!keepGoing)
+                {
+                    // add remaining results to the list.
+                    allResults.AddRange(results);
+                }
+            } while (keepGoing);
+
+            // Final status
+            Console.WriteLine($"Successfully applied {allResults.Count(r => r.Result != "Failed")} out of {allResults.Count} changes to {targetDb.Name}");
+            foreach (var result in allResults)
             {
                 Console.WriteLine($"{result.CommandType} ({result.OperationId}): {result.Result} => {result.Reason} ({result.CommandText})");
-                Console.WriteLine("---------------------------------------------------------------------------");
             }
+
+            return allResults;
+        }
+
+        internal virtual async Task<List<ScriptExecuteCommandResult>> UpdateFollowers(Database sourceDb, ILogger logger)
+        {
+            // Update followers with the latest changes
+            var results = new List<ScriptExecuteCommandResult>();
 
             foreach (var follower in sourceDb.Followers)
             {
@@ -44,53 +99,69 @@ namespace KustoSchemaTools.Parser.KustoWriter
 
                 Console.WriteLine();
                 Console.WriteLine();
+            }
 
-            }
-            var exs = results.Where(itm => itm.Result == "Failed").Select(itm => new Exception($"Execution failed for command \n{itm.CommandText} \n with reason\n{itm.Reason}")).ToList();
-            if (exs.Count == 1)
-            {
-                throw exs[0];
-            }
-            if (exs.Count > 1)
-            {
-                throw new AggregateException(exs);
-            }
+            return results;
         }
 
-
-        private async Task<List<ScriptExecuteCommandResult>> ApplyChangesToDatabase(string databaseName, List<IChange> changes, KustoClient client, ILogger logger)
+        internal virtual List<IChange> GenerateChanges(Database targetDb, Database sourceDb, ILogger logger)
         {
+            return DatabaseChanges.GenerateChanges(targetDb, sourceDb, targetDb.Name, logger);
+        }
+
+        internal virtual async Task<List<ScriptExecuteCommandResult>> ApplyChangesToDatabase(
+            string databaseName, List<IChange> changes, KustoClient client, ILogger logger)
+        {
+            // Filter and sort scripts
             var scripts = changes
                 .SelectMany(itm => itm.Scripts)
-                .Where(itm => itm.Order >= 0)
                 .Where(itm => itm.IsValid == true)
+                .Where(itm => itm.Order >= 0)
                 .OrderBy(itm => itm.Order)
                 .ToList();
 
+            logger.LogInformation($"Applying {scripts.Count} scripts to database '{databaseName}'");
+
             var results = new List<ScriptExecuteCommandResult>();
-            var batch = new List<DatabaseScriptContainer>();
-            foreach (var sc in scripts)
+
+            // Process scripts in batches, separating synchronous and asynchronous scripts
+            var pendingBatch = new List<DatabaseScriptContainer>();
+
+            foreach (var script in scripts)
             {
-                if (sc.IsAsync == false)
+                if (script.IsAsync)
                 {
-                    batch.Add(sc);
-                    continue;
+                    // If we encounter an async script, execute any pending sync scripts first
+                    if (pendingBatch.Count != 0)
+                    {
+                        var batchResults = await ExecutePendingSync(databaseName, client, logger, pendingBatch);
+                        results.AddRange(batchResults);
+                        pendingBatch.Clear();
+                    }
+
+                    // Then execute and record the async script
+                    logger.LogInformation($"Executing async script with order {script.Order}");
+                    var asyncResult = await ExecuteAsyncCommand(databaseName, client, logger, script);
+                    results.Add(asyncResult);
                 }
                 else
                 {
-                    var batchResults = await ExecutePendingSync(databaseName, client, logger, batch);
-                    results.AddRange(batchResults);
-                    var asyncResult = await ExecuteAsyncCommand(databaseName, client, logger, sc);
-                    results.Add(asyncResult);
+                    // Collect synchronous scripts into a batch
+                    pendingBatch.Add(script);
                 }
             }
-            var finalBatchResults = await ExecutePendingSync(databaseName, client, logger, batch);
-            results.AddRange(finalBatchResults);
-            return results;
 
+            // Execute any remaining synchronous scripts
+            if (pendingBatch.Any())
+            {
+                var finalBatchResults = await ExecutePendingSync(databaseName, client, logger, pendingBatch);
+                results.AddRange(finalBatchResults);
+            }
+
+            return results;
         }
 
-        private async Task<ScriptExecuteCommandResult> ExecuteAsyncCommand(string databaseName, KustoClient client, ILogger logger, DatabaseScriptContainer sc)
+        internal virtual async Task<ScriptExecuteCommandResult> ExecuteAsyncCommand(string databaseName, KustoClient client, ILogger logger, DatabaseScriptContainer sc)
         {
             var interval = TimeSpan.FromSeconds(5);
             var iterations = (int)(TimeSpan.FromHours(1) / interval);
@@ -111,7 +182,7 @@ namespace KustoSchemaTools.Parser.KustoWriter
                 logger.LogInformation($"Waiting for operation {operationId} to complete... current iteration: {cnt}/{iterations}");
                 var monitoringResult =  client.Client.ExecuteQuery(databaseName, monitoringCommand, new Kusto.Data.Common.ClientRequestProperties());
                 var operationState = monitoringResult.As<ScriptExecuteCommandResult>().FirstOrDefault();
-                
+
                 if (operationState != null && operationState?.IsFinal() == true)
                 {
                     operationState.CommandText = sc.Text;
@@ -122,12 +193,16 @@ namespace KustoSchemaTools.Parser.KustoWriter
             throw new Exception("Operation did not complete in a reasonable time");
         }
 
-        private static async Task<List<ScriptExecuteCommandResult>> ExecutePendingSync(string databaseName, KustoClient client, ILogger logger, List<DatabaseScriptContainer> scripts)
+        internal virtual async Task<List<ScriptExecuteCommandResult>> ExecutePendingSync(
+            string databaseName, KustoClient client, ILogger logger, List<DatabaseScriptContainer> scripts)
         {
-            if(scripts.Any() == false)
+            // this function will build a single .execute script from all the small scripts provided.
+            // Execute script is defined here: https://learn.microsoft.com/en-us/kusto/management/execute-database-script?view=azure-data-explorer
+            if (scripts.Count == 0)
             {
-                return new List<ScriptExecuteCommandResult>();
-            } 
+                return [];
+            }
+
             var sb = new StringBuilder();
             sb.AppendLine(".execute script with(ContinueOnErrors = true) <|");
             foreach (var sc in scripts)
@@ -136,9 +211,12 @@ namespace KustoSchemaTools.Parser.KustoWriter
             }
 
             var script = sb.ToString();
-            logger.LogInformation($"Applying sript:\n{script}");
+            logger.LogInformation($"Applying batch of {scripts.Count} scripts to database {databaseName}");
+            logger.LogDebug($"Script content:\n{script}");
+
             var result = await client.AdminClient.ExecuteControlCommandAsync(databaseName, script);
-            return result.As<ScriptExecuteCommandResult>();
+            var resultsList = result.As<ScriptExecuteCommandResult>();
+            return resultsList;
         }
     }
 }

--- a/KustoSchemaTools/Properties/AssemblyInfo.cs
+++ b/KustoSchemaTools/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// Make internals visible to the test project
+[assembly: InternalsVisibleTo("KustoSchemaTools.Tests")]


### PR DESCRIPTION
When there are interdependent function scripts that are being changed at the same time, sometimes there will be a sequencing problem. 

It may be that we can do work to get the script deployment sequence exactly perfect, but we can also try this. 

In this PR, we just keep applying changes until they stop working 😂 

This is a neat side effect of the way `.execute script` works in kusto when you allow it to continue on error. 