### PR TITLE
Fix WorkloadGroup enum serialization: ResourceKind and QueryConsistency

### DIFF
--- a/KustoSchemaTools.Tests/Model/WorkloadGroupSerializationTests.cs
+++ b/KustoSchemaTools.Tests/Model/WorkloadGroupSerializationTests.cs
@@ -1,0 +1,162 @@
+using KustoSchemaTools.Model;
+using Newtonsoft.Json.Linq;
+
+namespace KustoSchemaTools.Tests.Serialization
+{
+    public class WorkloadGroupSerializationTests
+    {
+        [Fact]
+        public void ResourceKind_ShouldSerializeAsString_NotInteger()
+        {
+            // Arrange - matches the exact scenario from github/data#10509
+            var policy = new WorkloadGroupPolicy
+            {
+                RequestRateLimitPolicies = new PolicyList<RequestRateLimitPolicy>
+                {
+                    new RequestRateLimitPolicy
+                    {
+                        IsEnabled = true,
+                        Scope = RateLimitScope.Principal,
+                        LimitKind = RateLimitKind.ResourceUtilization,
+                        Properties = new RateLimitProperties
+                        {
+                            ResourceKind = RateLimitResourceKind.TotalCpuSeconds,
+                            MaxUtilization = 36000,
+                            TimeWindow = TimeSpan.FromMinutes(15)
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var json = policy.ToJson();
+            var parsed = JObject.Parse(json);
+
+            // Assert - ResourceKind must be a string, not an integer
+            var resourceKind = parsed["RequestRateLimitPolicies"]![0]!["Properties"]!["ResourceKind"]!;
+            Assert.Equal(JTokenType.String, resourceKind.Type);
+            Assert.Equal("TotalCpuSeconds", resourceKind.Value<string>());
+        }
+
+        [Fact]
+        public void ResourceKind_RequestCount_ShouldSerializeAsString()
+        {
+            var policy = new WorkloadGroupPolicy
+            {
+                RequestRateLimitPolicies = new PolicyList<RequestRateLimitPolicy>
+                {
+                    new RequestRateLimitPolicy
+                    {
+                        IsEnabled = true,
+                        Scope = RateLimitScope.WorkloadGroup,
+                        LimitKind = RateLimitKind.ResourceUtilization,
+                        Properties = new RateLimitProperties
+                        {
+                            ResourceKind = RateLimitResourceKind.RequestCount,
+                            MaxUtilization = 100,
+                            TimeWindow = TimeSpan.FromMinutes(1)
+                        }
+                    }
+                }
+            };
+
+            var json = policy.ToJson();
+            var parsed = JObject.Parse(json);
+
+            var resourceKind = parsed["RequestRateLimitPolicies"]![0]!["Properties"]!["ResourceKind"]!;
+            Assert.Equal(JTokenType.String, resourceKind.Type);
+            Assert.Equal("RequestCount", resourceKind.Value<string>());
+        }
+
+        [Fact]
+        public void AllEnumProperties_ShouldSerializeAsStrings()
+        {
+            // Arrange - a policy with every enum populated
+            var policy = new WorkloadGroupPolicy
+            {
+                RequestRateLimitPolicies = new PolicyList<RequestRateLimitPolicy>
+                {
+                    new RequestRateLimitPolicy
+                    {
+                        IsEnabled = true,
+                        Scope = RateLimitScope.Principal,
+                        LimitKind = RateLimitKind.ResourceUtilization,
+                        Properties = new RateLimitProperties
+                        {
+                            ResourceKind = RateLimitResourceKind.TotalCpuSeconds,
+                            MaxUtilization = 36000,
+                            TimeWindow = TimeSpan.FromMinutes(15)
+                        }
+                    }
+                },
+                RequestRateLimitsEnforcementPolicy = new RequestRateLimitsEnforcementPolicy
+                {
+                    QueriesEnforcementLevel = QueriesEnforcementLevel.QueryHead,
+                    CommandsEnforcementLevel = CommandsEnforcementLevel.Database
+                },
+                QueryConsistencyPolicy = new QueryConsistencyPolicy
+                {
+                    QueryConsistency = new PolicyValue<QueryConsistency>
+                    {
+                        Value = QueryConsistency.WeakAffinitizedByDatabase,
+                        IsRelaxable = true
+                    }
+                }
+            };
+
+            // Act
+            var json = policy.ToJson();
+            var parsed = JObject.Parse(json);
+
+            // Assert - every enum value is a string
+            var rateLimitPolicy = parsed["RequestRateLimitPolicies"]![0]!;
+            Assert.Equal("Principal", rateLimitPolicy["Scope"]!.Value<string>());
+            Assert.Equal("ResourceUtilization", rateLimitPolicy["LimitKind"]!.Value<string>());
+            Assert.Equal("TotalCpuSeconds", rateLimitPolicy["Properties"]!["ResourceKind"]!.Value<string>());
+
+            var enforcement = parsed["RequestRateLimitsEnforcementPolicy"]!;
+            Assert.Equal("QueryHead", enforcement["QueriesEnforcementLevel"]!.Value<string>());
+            Assert.Equal("Database", enforcement["CommandsEnforcementLevel"]!.Value<string>());
+
+            var consistency = parsed["QueryConsistencyPolicy"]!["QueryConsistency"]!;
+            Assert.Equal("WeakAffinitizedByDatabase", consistency["Value"]!.Value<string>());
+        }
+
+        [Fact]
+        public void ToCreateScript_ShouldContainStringEnumValues()
+        {
+            // Arrange - the exact scenario from the issue
+            var workloadGroup = new WorkloadGroup
+            {
+                WorkloadGroupName = "test-group",
+                WorkloadGroupPolicy = new WorkloadGroupPolicy
+                {
+                    RequestRateLimitPolicies = new PolicyList<RequestRateLimitPolicy>
+                    {
+                        new RequestRateLimitPolicy
+                        {
+                            IsEnabled = true,
+                            Scope = RateLimitScope.Principal,
+                            LimitKind = RateLimitKind.ResourceUtilization,
+                            Properties = new RateLimitProperties
+                            {
+                                ResourceKind = RateLimitResourceKind.TotalCpuSeconds,
+                                MaxUtilization = 36000,
+                                TimeWindow = TimeSpan.FromMinutes(15)
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var script = workloadGroup.ToCreateScript();
+
+            // Assert - the script should contain string value, not integer
+            Assert.Contains("\"ResourceKind\": \"TotalCpuSeconds\"", script);
+            Assert.DoesNotContain("\"ResourceKind\": 1", script);
+            Assert.Contains("\"Scope\": \"Principal\"", script);
+            Assert.Contains("\"LimitKind\": \"ResourceUtilization\"", script);
+        }
+    }
+}

--- a/KustoSchemaTools/Model/WorkloadGroup.cs
+++ b/KustoSchemaTools/Model/WorkloadGroup.cs
@@ -26,6 +26,7 @@ namespace KustoSchemaTools.Model
         Database
     }
 
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
     public enum QueryConsistency
     {
         Strong,
@@ -244,6 +245,7 @@ namespace KustoSchemaTools.Model
         public int? MaxConcurrentRequests { get; set; }
 
         [JsonProperty("ResourceKind")]
+        [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public RateLimitResourceKind? ResourceKind { get; set; }
 
         [JsonProperty("MaxUtilization")]


### PR DESCRIPTION
## Summary

Fixes github/data#10509

`ResourceKind` in `RateLimitProperties` was missing the `[JsonConverter(typeof(StringEnumConverter))]` attribute, causing it to serialize as an integer (e.g. `1`) instead of the string value (e.g. `"TotalCpuSeconds"`).

**Before:**
```json
"ResourceKind": 1
```

**After:**
```json
"ResourceKind": "TotalCpuSeconds"
```

## Changes

1. **`RateLimitProperties.ResourceKind`** — Added `[JsonConverter(typeof(StringEnumConverter))]` attribute (property-level fix, consistent with every other enum property in the file).

2. **`QueryConsistency` enum** — Added `[JsonConverter(typeof(StringEnumConverter))]` at the type level. This enum is used inside `PolicyValue<T>` where a property-level converter cannot be applied (generic type parameter). Without this, `QueryConsistency` values would also serialize as integers.

## Test coverage

Added 4 new serialization tests in `WorkloadGroupSerializationTests`:
- `ResourceKind_ShouldSerializeAsString_NotInteger` — exact repro of the bug
- `ResourceKind_RequestCount_ShouldSerializeAsString` — covers the other enum value
- `AllEnumProperties_ShouldSerializeAsStrings` — comprehensive check of all enums in the policy
- `ToCreateScript_ShouldContainStringEnumValues` — end-to-end test of the generated Kusto script

All 70 tests pass (66 existing + 4 new).


Part of: https://github.com/github/data/issues/10509