### PR TITLE
Fix delta external table schema diff, script syntax, and cleanup

### DIFF
--- a/KustoSchemaTools/Changes/DatabaseChanges.cs
+++ b/KustoSchemaTools/Changes/DatabaseChanges.cs
@@ -113,6 +113,21 @@ namespace KustoSchemaTools.Changes
             result.AddRange(mvChanges);
             result.AddRange(GenerateScriptCompareChanges(oldState, newState, db => db.ContinuousExports, nameof(newState.ContinuousExports), log));
             result.AddRange(GenerateScriptCompareChanges(oldState, newState, db => db.Functions, nameof(newState.Functions), log));
+
+            // For delta external tables, the schema is auto-inferred from the delta log.
+            // If the YAML doesn't specify a schema, clear the cluster-side schema so it
+            // doesn't cause a perpetual diff. If the YAML does specify a schema, keep the
+            // cluster-side schema for proper comparison.
+            foreach (var et in newState.ExternalTables)
+            {
+                if (et.Value.Kind?.ToLower() == "delta"
+                    && et.Value.Schema?.Any() != true
+                    && oldState.ExternalTables.ContainsKey(et.Key))
+                {
+                    oldState.ExternalTables[et.Key].Schema = null;
+                }
+            }
+
             result.AddRange(GenerateScriptCompareChanges(oldState, newState, db => db.ExternalTables, nameof(newState.ExternalTables), log));
 
             if (newState.EntityGroups.Any())

--- a/KustoSchemaTools/Changes/DatabaseChanges.cs
+++ b/KustoSchemaTools/Changes/DatabaseChanges.cs
@@ -122,9 +122,10 @@ namespace KustoSchemaTools.Changes
             {
                 if (et.Value.Kind?.ToLower() == "delta"
                     && et.Value.Schema?.Any() != true
-                    && oldState.ExternalTables.ContainsKey(et.Key))
+                    && oldState.ExternalTables.TryGetValue(et.Key, out var oldExternalTable)
+                    && oldExternalTable.Kind?.ToLower() == "delta")
                 {
-                    oldState.ExternalTables[et.Key].Schema = null;
+                    oldExternalTable.Schema = null;
                 }
             }
 

--- a/KustoSchemaTools/Model/ExternalTable.cs
+++ b/KustoSchemaTools/Model/ExternalTable.cs
@@ -137,8 +137,6 @@ namespace KustoSchemaTools.Model
 
         private string CreateDeltaScript(string name)
         {
-            if (string.IsNullOrWhiteSpace(DataFormat)) throw new ArgumentException("DataFormat can't be empty");
-
             var sb = new StringBuilder();
             sb.AppendLine($".create-or-alter external table {name}");
             if (Schema?.Any() == true)
@@ -146,11 +144,18 @@ namespace KustoSchemaTools.Model
                 sb.AppendLine($"({string.Join(", ", Schema.Select(c => $"{c.Key.BracketIfIdentifier()}:{c.Value}"))})");
             }
             sb.AppendLine("kind=delta");            
-            sb.AppendLine($"(h@'{ConnectionString}'");
+            sb.AppendLine($"(h@'{ConnectionString}')");
 
+            var withProps = new List<string>();
+            if (!string.IsNullOrEmpty(Folder)) withProps.Add($"folder='{Folder}'");
+            if (!string.IsNullOrEmpty(DocString)) withProps.Add($"docString='{DocString}'");
             var ext = string.IsNullOrWhiteSpace(FileExtensions) ? "" : FileExtensions.StartsWith(".") ? FileExtensions : "." + FileExtensions;
+            if (!string.IsNullOrEmpty(ext)) withProps.Add($"fileExtension='{ext}'");
 
-            sb.AppendLine($"with(folder='{Folder}', docString='{DocString}', fileExtension='{ext}') ");
+            if (withProps.Any())
+            {
+                sb.AppendLine($"with({string.Join(", ", withProps)})");
+            }
 
             return sb.ToString();
         }

--- a/KustoSchemaTools/Model/ExternalTable.cs
+++ b/KustoSchemaTools/Model/ExternalTable.cs
@@ -137,6 +137,8 @@ namespace KustoSchemaTools.Model
 
         private string CreateDeltaScript(string name)
         {
+            if (string.IsNullOrWhiteSpace(ConnectionString)) throw new ArgumentException("ConnectionString can't be empty");
+
             var sb = new StringBuilder();
             sb.AppendLine($".create-or-alter external table {name}");
             if (Schema?.Any() == true)


### PR DESCRIPTION
Fixes for delta external tables:
1. Schema perpetual diff: The bulk loader populates the schema for all external tables from the cluster, but delta tables can auto-infer their schema from the delta, so YAML configs may intentionally omit it. This caused a perpetual diff on every run. 
2. Missing closing parenthesis in the CreateDeltaScript connection string
3. Remove unnecessary dataFormat requirement because Delta tables don't use `dataformat=` in the Kusto command syntax. 
4. Only emit `with()` properties when set; Delta script no longer emits empty `folder='', docString='', fileExtension=''` when not specified in YAML. 

Fixes github/data#11973